### PR TITLE
Adding builtin help command that prints default builtins

### DIFF
--- a/shrs/src/builtin/help.rs
+++ b/shrs/src/builtin/help.rs
@@ -1,0 +1,33 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use super::{BuiltinCmd, Builtins};
+use crate::{
+    hooks::ChangeDirCtx,
+    shell::{dummy_child, Context, Runtime},
+    Shell,
+};
+
+#[derive(Default)]
+pub struct HelpBuiltin {}
+impl BuiltinCmd for HelpBuiltin {
+    fn run(
+        &self,
+        sh: &Shell,
+        ctx: &mut Context,
+        rt: &mut Runtime,
+        args: &Vec<String>,
+    ) -> anyhow::Result<std::process::Child> {
+        let cmds = Builtins::default().builtins.into_keys();
+
+        println!("Builtin Commands:");
+
+        for cmd in cmds {
+            println!("{}", cmd);
+        }
+
+        dummy_child()
+    }
+}

--- a/shrs/src/builtin/help.rs
+++ b/shrs/src/builtin/help.rs
@@ -20,7 +20,7 @@ impl BuiltinCmd for HelpBuiltin {
         rt: &mut Runtime,
         args: &Vec<String>,
     ) -> anyhow::Result<std::process::Child> {
-        let cmds = Builtins::default().builtins.into_keys();
+        let cmds = sh.builtins.builtins.keys();
 
         println!("Builtin Commands:");
 

--- a/shrs/src/builtin/mod.rs
+++ b/shrs/src/builtin/mod.rs
@@ -3,6 +3,7 @@ mod cd;
 mod debug;
 mod exit;
 mod export;
+mod help;
 mod history;
 mod jobs;
 mod source;
@@ -15,8 +16,8 @@ use std::{
 
 use self::{
     alias::AliasBuiltin, cd::CdBuiltin, debug::DebugBuiltin, exit::ExitBuiltin,
-    export::ExportBuiltin, history::HistoryBuiltin, jobs::JobsBuiltin, source::SourceBuiltin,
-    unalias::UnaliasBuiltin,
+    export::ExportBuiltin, help::HelpBuiltin, history::HistoryBuiltin, jobs::JobsBuiltin,
+    source::SourceBuiltin, unalias::UnaliasBuiltin,
 };
 use crate::{
     shell::{Context, Runtime},
@@ -93,6 +94,10 @@ impl Default for Builtins {
                 (
                     "jobs",
                     Box::new(JobsBuiltin::default()) as Box<dyn BuiltinCmd>,
+                ),
+                (
+                    "help",
+                    Box::new(HelpBuiltin::default()) as Box<dyn BuiltinCmd>,
                 ),
             ]),
         }


### PR DESCRIPTION
Initial implementation for #84.

> help
Builtin Commands:
source
export
history
unalias
alias
exit
help
cd
jobs
debug

Need a way to access list of builtins from within a command so that non default commands would also show up. Maybe help could also have option to show description of command?