### PR TITLE
Job Timer

### DIFF
--- a/shrs/src/hooks.rs
+++ b/shrs/src/hooks.rs
@@ -14,7 +14,7 @@ use std::{io::BufWriter, marker::PhantomData, path::PathBuf};
 
 use crossterm::{style::Print, QueueableCommand};
 
-use crate::{jobs::ExitStatus, Context, Runtime, Shell};
+use crate::{jobs::ExitInfo, Context, Runtime, Shell};
 
 pub type HookFn<C: Clone> =
     fn(sh: &Shell, sh_ctx: &mut Context, sh_rt: &mut Runtime, ctx: &C) -> anyhow::Result<()>;
@@ -97,7 +97,7 @@ pub fn change_dir_hook(
 /// Context for [JobExit]
 #[derive(Clone)]
 pub struct JobExitCtx {
-    pub status: ExitStatus,
+    pub info: ExitInfo,
 }
 
 /// Default [JobExitHook]
@@ -107,7 +107,8 @@ pub fn job_exit_hook(
     sh_rt: &mut Runtime,
     ctx: &JobExitCtx,
 ) -> anyhow::Result<()> {
-    println!("[exit +{}]", ctx.status.code());
+    println!("[exit +{}]", ctx.info.code());
+    // println!("{} ms", ctx.info.job_duration.as_millis());
     Ok(())
 }
 

--- a/shrs/src/hooks.rs
+++ b/shrs/src/hooks.rs
@@ -21,10 +21,7 @@ pub type HookFn<C: Clone> =
 
 /// Context for [StartupHook]
 #[derive(Clone)]
-pub struct StartupCtx {
-    /// How much time it has taken for the shell to initialize
-    pub startup_time: usize,
-}
+pub struct StartupCtx {}
 
 /// Default [StartupHook]
 pub fn startup_hook(


### PR DESCRIPTION
#113 This pr primarily adds a JobTimer to JobInfo. job start_time is set when init() is called. The job finishes when retain() confirms that the job is complete. This is currently not the actual time for the command to finish, since jobs status is only checked whenever a new command is entered. 

When #112 is implemented this issue can be solved (Infinite loop or some kind of listener). ExitStatus has also been changed to ExitInfo since there needed to be a way to share the timer with the exit_handler. Timer could be shared separately from status however there may be more things that could be shared and it means less parameters.