### PR TITLE
Insert and Change commands

### DIFF
--- a/shrs_line/src/line.rs
+++ b/shrs_line/src/line.rs
@@ -386,7 +386,9 @@ impl Line {
                     for _ in 0..repeat {
                         // special cases (possibly consulidate with execute_vi somehow)
                         match action {
-                            Action::Insert => {
+                            Action::Insert(motion) => {
+                                //being explicit
+                                ctx.cb.execute_vi(Action::Move(motion));
                                 ctx.mode = LineMode::Insert;
                             },
                             Action::Change(motion) => {

--- a/shrs_vi/src/ast.rs
+++ b/shrs_vi/src/ast.rs
@@ -6,6 +6,7 @@ pub struct Command {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Motion {
+    None,
     BackWord,
     WordPunc,
     Word,
@@ -28,5 +29,5 @@ pub enum Action {
     Change(Motion),
     Yank(Motion),
     Move(Motion),
-    Insert,
+    Insert(Motion),
 }

--- a/shrs_vi/src/grammar.lalrpop
+++ b/shrs_vi/src/grammar.lalrpop
@@ -28,7 +28,10 @@ pub Action: Action = {
     <a:DeleteAction> => a,
     <a:ChangeAction> => a,
     "y" <m:Motion> => Action::Yank(m),
-    "i" => Action::Insert,
+    "i" => Action::Insert(Motion::None),
+    "I" => Action::Insert(Motion::Start),
+    "a" => Action::Insert(Motion::Right),
+    "A" => Action::Insert(Motion::End),
     "x" => Action::Delete(Motion::Char),
     <m:Motion> => Action::Move(m)
 };
@@ -43,6 +46,8 @@ pub ChangeAction: Action = {
     "c" "c" => Action::Change(Motion::All),
     "C" => Action::Change(Motion::End),
     "c" <m:Motion> => Action::Change(m),
+    "s" => Action::Change(Motion::Right),
+    "S" => Action::Change(Motion::All)
 };
 
 pub Repeat: u32 = <s:r"[0-9]+"> => u32::from_str_radix(s, 10).unwrap();

--- a/shrs_vi/src/grammar.lalrpop
+++ b/shrs_vi/src/grammar.lalrpop
@@ -32,7 +32,7 @@ pub Action: Action = {
     "I" => Action::Insert(Motion::Start),
     "a" => Action::Insert(Motion::Right),
     "A" => Action::Insert(Motion::End),
-    "x" => Action::Delete(Motion::Char),
+    "x" => Action::Delete(Motion::Right),
     <m:Motion> => Action::Move(m)
 };
 


### PR DESCRIPTION
Added I, a, A, s and S to Insert and Change commands, Motion was added to Insert and None was added to Insert. This allows for vim commands that insert and change position. 