### PR TITLE
Vim chain

### DIFF
--- a/shrs_line/src/line.rs
+++ b/shrs_line/src/line.rs
@@ -385,28 +385,17 @@ impl Line {
                 if let Ok(Command { repeat, action }) = Parser::new().parse(&self.normal_keys) {
                     for _ in 0..repeat {
                         // special cases (possibly consulidate with execute_vi somehow)
-                        match action {
-                            Action::Insert(motion) => {
-                                //being explicit
-                                ctx.cb.execute_vi(Action::Move(motion));
-                                ctx.mode = LineMode::Insert;
-                            },
-                            Action::Change(motion) => {
-                                ctx.cb.execute_vi(Action::Delete(motion));
-                                ctx.mode = LineMode::Insert;
-                            },
-                            Action::Move(motion) => match motion {
+
+                        if let Ok(mode) = ctx.cb.execute_vi(action.clone()) {
+                            ctx.mode = mode;
+                        }
+                        if let Action::Move(motion) = action {
+                            action.clone();
+                            match motion {
                                 Motion::Up => self.history_up(ctx)?,
                                 Motion::Down => self.history_down(ctx)?,
-                                _ => {
-                                    // purposely unchecked
-                                    ctx.cb.execute_vi(action);
-                                },
-                            },
-                            action => {
-                                // purposely unchecked
-                                ctx.cb.execute_vi(action);
-                            },
+                                _ => {},
+                            }
                         }
                     }
 

--- a/shrs_line/src/line.rs
+++ b/shrs_line/src/line.rs
@@ -390,7 +390,6 @@ impl Line {
                             ctx.mode = mode;
                         }
                         if let Action::Move(motion) = action {
-                            action.clone();
                             match motion {
                                 Motion::Up => self.history_up(ctx)?,
                                 Motion::Down => self.history_down(ctx)?,

--- a/shrs_vi/src/ast.rs
+++ b/shrs_vi/src/ast.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Command {
     pub repeat: u32,
     pub action: Action,
@@ -21,11 +21,12 @@ pub enum Motion {
     Find(char),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Action {
     Delete(Motion),
     Change(Motion),
     Yank(Motion),
     Move(Motion),
-    Insert(Motion),
+    Insert,
+    Chain(Box<Action>, Box<Action>),
 }

--- a/shrs_vi/src/ast.rs
+++ b/shrs_vi/src/ast.rs
@@ -24,7 +24,6 @@ pub enum Motion {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Action {
     Delete(Motion),
-    Change(Motion),
     Yank(Motion),
     Move(Motion),
     Insert,

--- a/shrs_vi/src/grammar.lalrpop
+++ b/shrs_vi/src/grammar.lalrpop
@@ -28,10 +28,10 @@ pub Action: Action = {
     <a:DeleteAction> => a,
     <a:ChangeAction> => a,
     "y" <m:Motion> => Action::Yank(m),
-    "i" => Action::Insert(Motion::None),
-    "I" => Action::Insert(Motion::Start),
-    "a" => Action::Insert(Motion::Right),
-    "A" => Action::Insert(Motion::End),
+    "i" => Action::Insert,
+    "I" => Action::Chain(Box::new(Action::Move(Motion::Start)), Box::new(Action::Insert)),
+    "a" => Action::Chain(Box::new(Action::Move(Motion::Right)), Box::new(Action::Insert)),
+    "A" => Action::Chain(Box::new(Action::Move(Motion::End)), Box::new(Action::Insert)),
     "x" => Action::Delete(Motion::Right),
     <m:Motion> => Action::Move(m)
 };
@@ -43,11 +43,12 @@ pub DeleteAction: Action = {
 };
 
 pub ChangeAction: Action = {
-    "c" "c" => Action::Change(Motion::All),
-    "C" => Action::Change(Motion::End),
-    "c" <m:Motion> => Action::Change(m),
-    "s" => Action::Change(Motion::Right),
-    "S" => Action::Change(Motion::All)
+    "c" "c" => Action::Chain(Box::new(Action::Delete(Motion::All)), Box::new(Action::Insert)),
+    "C" => Action::Chain(Box::new(Action::Delete(Motion::End)), Box::new(Action::Insert)),
+    "c" <m:Motion> => Action::Chain(Box::new(Action::Delete(m)), Box::new(Action::Insert)),
+    "s" => Action::Chain(Box::new(Action::Delete(Motion::Right)), Box::new(Action::Insert)),
+    "S" => Action::Chain(Box::new(Action::Delete(Motion::All)), Box::new(Action::Insert)),
+
 };
 
 pub Repeat: u32 = <s:r"[0-9]+"> => u32::from_str_radix(s, 10).unwrap();


### PR DESCRIPTION
This pr is an implementation for a suggestion on #126. There is now a chain action that allows for commands to be chained. This takes away the need for insert to have motion and allows the Change motion to be completely rewritten as chain delete and insert. 

Simplified line.rs so that almost all actions happen within execute_vi. History has to happen in line.rs unless ctx is passed to cb. execute_vi assumes current mode is normal and returns the mode that should be changed into. This allows for insert to be completely encapsulated in execute_vi.

## Considerations
Currently Action::Chain allows for recursion of Actions, which could be used to implement more complex commands in a more modular manner keeping the number of different actions smaller, but is not necessary.

execute_vi and motion_to_loc do not need to return a Result since everything returns a non error value using `.unwrap_or` and is being wrapped by Ok. 





