### PR TITLE
hook refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "anymap"
+version = "1.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1067,7 @@ name = "shrs_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "anymap",
  "clap",
  "crossbeam-channel",
  "crossterm",

--- a/plugins/shrs_command_timer/src/lib.rs
+++ b/plugins/shrs_command_timer/src/lib.rs
@@ -55,8 +55,8 @@ pub struct CommandTimerPlugin;
 
 impl Plugin for CommandTimerPlugin {
     fn init(&self, shell: &mut shrs::ShellConfig) {
-        shell.hooks.before_command.register(before_command_hook);
-        shell.hooks.after_command.register(after_command_hook);
+        shell.hooks.register(before_command_hook);
+        shell.hooks.register(after_command_hook);
         shell.state.insert(CommandTimerState::new());
     }
 }

--- a/plugins/shrs_output_capture/src/lib.rs
+++ b/plugins/shrs_output_capture/src/lib.rs
@@ -22,7 +22,7 @@ pub struct OutputCapturePlugin;
 
 impl Plugin for OutputCapturePlugin {
     fn init(&self, shell: &mut shrs::ShellConfig) {
-        shell.hooks.after_command.register(after_command_hook);
+        shell.hooks.register(after_command_hook);
         shell.builtins.insert("again", AgainBuiltin::new());
         shell.state.insert(OutputCaptureState::new());
     }

--- a/shrs/src/shell.rs
+++ b/shrs/src/shell.rs
@@ -115,9 +115,9 @@ impl ShellConfig {
         };
         let sh = Shell {
             builtins: self.builtins,
-            hooks: self.hooks,
             theme: self.theme,
             lang: self.lang,
+            hooks: self.hooks,
         };
         let mut readline = self.readline;
 
@@ -135,11 +135,11 @@ fn run_shell(
     sig_handler()?;
     rt.env.load();
 
-    let res = sh.hooks.startup.run(
+    let res = sh.hooks.run::<StartupCtx>(
         sh,
         ctx,
         rt,
-        &StartupCtx {
+        StartupCtx {
             startup_time: ctx.startup_time.elapsed(),
         },
     );
@@ -170,7 +170,7 @@ fn run_shell(
             raw_command: line.clone(),
             command: line.clone(),
         };
-        sh.hooks.before_command.run(sh, ctx, rt, &hook_ctx)?;
+        sh.hooks.run::<BeforeCommandCtx>(sh, ctx, rt, hook_ctx)?;
 
         match sh.lang.eval(sh, ctx, rt, line) {
             Ok(_) => {},
@@ -184,7 +184,8 @@ fn run_shell(
         });
 
         for status in exit_statuses.into_iter() {
-            sh.hooks.job_exit.run(sh, ctx, rt, &JobExitCtx { status });
+            sh.hooks
+                .run::<JobExitCtx>(sh, ctx, rt, JobExitCtx { status });
         }
     }
 }

--- a/shrs_core/Cargo.toml
+++ b/shrs_core/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.1", features = ["derive"] }
 crossterm = "0.26"
 derive_builder = "0.12"
 dirs = "5"
+anymap = "1.0.0-beta.2"
 
 pino_deref = "0.1"
 

--- a/shrs_core/src/builtin/cd.rs
+++ b/shrs_core/src/builtin/cd.rs
@@ -48,7 +48,7 @@ impl BuiltinCmd for CdBuiltin {
             new_dir: path.clone(),
         };
         // need to be able to call hook from here
-        sh.hooks.change_dir.run(sh, ctx, rt, &hook_ctx);
+        sh.hooks.run::<ChangeDirCtx>(sh, ctx, rt, hook_ctx);
 
         rt.working_dir = path.clone();
         rt.env.set("PWD", path.to_str().unwrap());

--- a/shrs_core/src/shell.rs
+++ b/shrs_core/src/shell.rs
@@ -118,7 +118,7 @@ pub fn command_output(
         cmd_time: 0.0,
         cmd_output: output,
     };
-    sh.hooks.after_command.run(sh, ctx, rt, &hook_ctx)?;
+    sh.hooks.run::<AfterCommandCtx>(sh, ctx, rt, hook_ctx)?;
 
     Ok(ExitStatus(exit_status))
 }

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -138,10 +138,8 @@ a rusty POSIX shell | build {}"#,
         println!("{welcome_str}");
         Ok(())
     };
-    let hooks = Hooks {
-        startup: HookList::from_iter(vec![startup_msg]),
-        ..Default::default()
-    };
+    let mut hooks = Hooks::default();
+    hooks.register(startup_msg);
 
     // =-=-= Shell =-=-=
     // Construct the final shell


### PR DESCRIPTION
Refactor hooks to take in a generic type parameter instead of being a field in an object. This allows arbitrary new hooks to be implemented (especially by third party)