### PR TITLE
Nithin/return_output_from_eval

### DIFF
--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -224,10 +224,10 @@ fn run_shell(
             match output {
                 Ok(cmd_output) => {
                     if !cmd_output.stdout.is_empty() {
-                        println!("{}", cmd_output.stdout);
+                        print!("{}", cmd_output.stdout);
                     }
                     if !cmd_output.stderr.is_empty() {
-                        eprintln!("{}", cmd_output.stderr);
+                        eprint!("{}", cmd_output.stderr);
                     }
 
                     let _ = sh.hooks.run(

--- a/crates/shrs_core/src/cmd_output.rs
+++ b/crates/shrs_core/src/cmd_output.rs
@@ -22,15 +22,13 @@ impl CmdOutput {
             status,
         }
     }
-    pub fn from_process_output(o: process::Output) -> Self {
+}
+impl From<process::Output> for CmdOutput {
+    fn from(o: process::Output) -> Self {
         CmdOutput {
             stdout: String::from_utf8_lossy(&o.stdout).to_string(),
             stderr: String::from_utf8_lossy(&o.stderr).to_string(),
             status: o.status,
         }
-    }
-    //if stdout or stderr are empty this will only return one, otherwise err after out
-    pub fn out(&self) -> String {
-        self.stdout.clone() + self.stderr.as_str()
     }
 }

--- a/crates/shrs_core/src/cmd_output.rs
+++ b/crates/shrs_core/src/cmd_output.rs
@@ -1,0 +1,36 @@
+use std::{
+    os::unix::process::ExitStatusExt,
+    process::{self, ExitStatus, Output},
+};
+
+use pino_deref::Deref;
+
+#[derive(Clone, Debug)]
+pub struct CmdOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub status: ExitStatus,
+}
+impl CmdOutput {
+    pub fn empty() -> CmdOutput {
+        CmdOutput::new(String::new(), String::new(), ExitStatus::from_raw(0))
+    }
+    pub fn new(stdout: String, stderr: String, status: ExitStatus) -> Self {
+        CmdOutput {
+            stdout,
+            stderr,
+            status,
+        }
+    }
+    pub fn from_process_output(o: process::Output) -> Self {
+        CmdOutput {
+            stdout: String::from_utf8_lossy(&o.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&o.stderr).to_string(),
+            status: o.status,
+        }
+    }
+    //if stdout or stderr are empty this will only return one, otherwise err after out
+    pub fn out(&self) -> String {
+        self.stdout.clone() + self.stderr.as_str()
+    }
+}

--- a/crates/shrs_core/src/hooks.rs
+++ b/crates/shrs_core/src/hooks.rs
@@ -16,13 +16,14 @@ use std::{
     io::BufWriter,
     marker::PhantomData,
     path::PathBuf,
+    process::ExitStatus,
     time::Duration,
 };
 
 use crossterm::{style::Print, QueueableCommand};
 
 use crate::{
-    jobs::ExitStatus,
+    cmd_output::CmdOutput,
     shell::{Context, Runtime, Shell},
 };
 
@@ -77,12 +78,8 @@ pub fn before_command_hook(
 pub struct AfterCommandCtx {
     /// The command that was ran
     pub command: String,
-    /// Exit code of previous command
-    pub exit_code: i32,
-    // /// Amount of time it took to run command
-    // pub cmd_time: f32,
     /// Command output
-    pub cmd_output: String,
+    pub cmd_output: CmdOutput,
 }
 
 /// Default implementation for [AfterCommandCtx]
@@ -127,7 +124,7 @@ pub fn job_exit_hook(
     sh_rt: &mut Runtime,
     ctx: &JobExitCtx,
 ) -> anyhow::Result<()> {
-    println!("[exit +{}]", ctx.status.code());
+    println!("[exit +{:?}]", ctx.status.code());
     Ok(())
 }
 

--- a/crates/shrs_core/src/jobs.rs
+++ b/crates/shrs_core/src/jobs.rs
@@ -1,25 +1,13 @@
 //! Abstraction layer for processes
 use std::{
     collections::{hash_map::Iter, HashMap},
-    process::Child,
+    process::{Child, ExitStatus},
 };
 
 use anyhow::anyhow;
 use pino_deref::Deref;
 
 pub type JobId = u32;
-
-#[derive(Deref, Clone)]
-pub struct ExitStatus(pub i32);
-
-impl ExitStatus {
-    pub fn success(&self) -> bool {
-        self.0 == 0
-    }
-    pub fn code(&self) -> i32 {
-        self.0
-    }
-}
 
 pub struct JobInfo {
     pub child: Child,
@@ -60,7 +48,7 @@ impl Jobs {
         self.jobs.retain(|k, v| {
             match v.child.try_wait() {
                 Ok(Some(status)) => {
-                    exit_handler(ExitStatus(status.code().unwrap()));
+                    exit_handler(status);
                     false
                 },
                 Ok(None) => true,

--- a/crates/shrs_core/src/lang.rs
+++ b/crates/shrs_core/src/lang.rs
@@ -2,7 +2,10 @@
 //!
 //!
 
-use crate::shell::{Context, Runtime, Shell};
+use crate::{
+    cmd_output::CmdOutput,
+    shell::{Context, Runtime, Shell},
+};
 
 /// Trait to implement a shell command language
 pub trait Lang {
@@ -13,7 +16,7 @@ pub trait Lang {
         ctx: &mut Context,
         rt: &mut Runtime,
         cmd: String,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<CmdOutput>;
     fn name(&self) -> String;
     fn needs_line_check(&self, cmd: String) -> bool;
 }

--- a/crates/shrs_core/src/lib.rs
+++ b/crates/shrs_core/src/lib.rs
@@ -8,6 +8,7 @@ extern crate lazy_static;
 
 pub mod alias;
 pub mod builtin;
+pub mod cmd_output;
 pub mod env;
 pub mod hooks;
 pub mod jobs;
@@ -24,9 +25,10 @@ pub mod prelude {
     pub use crate::{
         alias::{Alias, AliasInfo, AliasRule, AliasRuleCtx},
         builtin::{BuiltinCmd, BuiltinStatus, Builtins},
+        cmd_output::CmdOutput,
         env::Env,
         hooks::{Hook, HookFn, Hooks, *},
-        jobs::{ExitStatus, JobId, JobInfo, Jobs},
+        jobs::{JobId, JobInfo, Jobs},
         lang::Lang,
         prompt::*,
         shell::{Context, Runtime, Shell},

--- a/crates/shrs_core/src/shell.rs
+++ b/crates/shrs_core/src/shell.rs
@@ -25,7 +25,7 @@ use crate::{
     builtin::Builtins,
     env::Env,
     hooks::{AfterCommandCtx, BeforeCommandCtx, ChangeDirCtx, Hooks, JobExitCtx, StartupCtx},
-    jobs::{ExitStatus, Jobs},
+    jobs::Jobs,
     lang::Lang,
     signal::Signals,
     state::State,

--- a/crates/shrs_lang/src/lang.rs
+++ b/crates/shrs_lang/src/lang.rs
@@ -1,8 +1,11 @@
+use std::{os::unix::process::ExitStatusExt, process::ExitStatus};
+
 use shrs_core::{
     lang::Lang,
+    prelude::CmdOutput,
     shell::{Context, Runtime, Shell},
 };
-use shrs_job::initialize_job_control;
+use shrs_job::{initialize_job_control, Output};
 use thiserror::Error;
 
 use crate::{
@@ -43,7 +46,7 @@ impl Lang for PosixLang {
         ctx: &mut Context,
         rt: &mut Runtime,
         line: String,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<CmdOutput> {
         // TODO rewrite the error handling here better
         let lexer = Lexer::new(&line);
         let parser = Parser::new();
@@ -61,7 +64,11 @@ impl Lang for PosixLang {
 
         run_job(&mut job_manager, procs, pgid, true)?;
 
-        Ok(())
+        Ok(CmdOutput::new(
+            "".to_string(),
+            "".to_string(),
+            ExitStatus::from_raw(0),
+        ))
     }
 
     fn name(&self) -> String {

--- a/crates/shrs_lang/src/lang.rs
+++ b/crates/shrs_lang/src/lang.rs
@@ -65,8 +65,8 @@ impl Lang for PosixLang {
         run_job(&mut job_manager, procs, pgid, true)?;
 
         Ok(CmdOutput::new(
-            "".to_string(),
-            "".to_string(),
+            String::new(),
+            String::new(),
             ExitStatus::from_raw(0),
         ))
     }

--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -157,7 +157,7 @@ impl<'a> LineCtx<'a> {
             history_ind: HistoryInd::Prompt,
             saved_line: String::new(),
             mode: LineMode::Insert,
-            lines: "".to_string(),
+            lines: String::new(),
             sh,
             ctx,
             rt,

--- a/crates/shrs_line/src/painter.rs
+++ b/crates/shrs_line/src/painter.rs
@@ -28,7 +28,7 @@ pub struct StyledBuf {
 impl StyledBuf {
     pub fn empty() -> Self {
         Self {
-            content: "".to_string(),
+            content: String::new(),
             styles: vec![],
         }
     }

--- a/plugins/shrs_autocd/src/lib.rs
+++ b/plugins/shrs_autocd/src/lib.rs
@@ -11,23 +11,23 @@ pub fn after_command_hook(
     ctx: &AfterCommandCtx,
 ) -> anyhow::Result<()> {
     // Bash exit code for invalid command
-    // if let Some(exit_code) = ctx.exit_code.code() {
-    //     if exit_code == 127 {
-    //         // Check if the command name matches a directory
-    //         let Some(cmd_name) = ctx.command.split(' ').next() else { return Ok(()) };
-    //
-    //         let paths = fs::read_dir("./").unwrap();
-    //
-    //         for path in paths {
-    //             let path = path.unwrap();
-    //             println!("{:?}", path);
-    //             if path.file_type().unwrap().is_dir() && path.file_name() == cmd_name {
-    //                 set_working_dir(sh, sh_ctx, sh_rt, &path.path(), true)?;
-    //                 return Ok(());
-    //             }
-    //         }
-    //     }
-    // }
+    if let Some(exit_code) = ctx.cmd_output.status.code() {
+        if exit_code == 127 {
+            // Check if the command name matches a directory
+            let Some(cmd_name) = ctx.command.split(' ').next() else { return Ok(()) };
+
+            let paths = fs::read_dir("./").unwrap();
+
+            for path in paths {
+                let path = path.unwrap();
+                println!("{:?}", path);
+                if path.file_type().unwrap().is_dir() && path.file_name() == cmd_name {
+                    set_working_dir(sh, sh_ctx, sh_rt, &path.path(), true)?;
+                    return Ok(());
+                }
+            }
+        }
+    }
 
     Ok(())
 }

--- a/plugins/shrs_autocd/src/lib.rs
+++ b/plugins/shrs_autocd/src/lib.rs
@@ -11,20 +11,23 @@ pub fn after_command_hook(
     ctx: &AfterCommandCtx,
 ) -> anyhow::Result<()> {
     // Bash exit code for invalid command
-    if ctx.exit_code == 127 {
-        // Check if the command name matches a directory
-        let Some(cmd_name) = ctx.command.split(' ').next() else { return Ok(()) };
-
-        let paths = fs::read_dir("./").unwrap();
-
-        for path in paths {
-            let path = path.unwrap();
-            if path.file_type().unwrap().is_dir() && path.file_name() == cmd_name {
-                set_working_dir(sh, sh_ctx, sh_rt, &path.path(), true)?;
-                return Ok(());
-            }
-        }
-    }
+    // if let Some(exit_code) = ctx.exit_code.code() {
+    //     if exit_code == 127 {
+    //         // Check if the command name matches a directory
+    //         let Some(cmd_name) = ctx.command.split(' ').next() else { return Ok(()) };
+    //
+    //         let paths = fs::read_dir("./").unwrap();
+    //
+    //         for path in paths {
+    //             let path = path.unwrap();
+    //             println!("{:?}", path);
+    //             if path.file_type().unwrap().is_dir() && path.file_name() == cmd_name {
+    //                 set_working_dir(sh, sh_ctx, sh_rt, &path.path(), true)?;
+    //                 return Ok(());
+    //             }
+    //         }
+    //     }
+    // }
 
     Ok(())
 }

--- a/plugins/shrs_mux/src/lang.rs
+++ b/plugins/shrs_mux/src/lang.rs
@@ -72,7 +72,7 @@ impl Lang for NuLang {
             .spawn()?;
         let output = handle.wait_with_output()?;
 
-        Ok(CmdOutput::from_process_output(output))
+        Ok(CmdOutput::from(output))
     }
 
     fn name(&self) -> String {
@@ -107,7 +107,7 @@ impl Lang for PythonLang {
             .spawn()?;
         let output = handle.wait_with_output()?;
 
-        Ok(CmdOutput::from_process_output(output))
+        Ok(CmdOutput::from(output))
     }
 
     fn name(&self) -> String {
@@ -142,7 +142,7 @@ impl Lang for BashLang {
             .spawn()?;
         let output = handle.wait_with_output()?;
 
-        Ok(CmdOutput::from_process_output(output))
+        Ok(CmdOutput::from(output))
     }
 
     fn name(&self) -> String {

--- a/plugins/shrs_mux/src/lang.rs
+++ b/plugins/shrs_mux/src/lang.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, process::Command};
+use std::{
+    collections::HashMap,
+    io::Read,
+    process::{Command, ExitStatus, Stdio},
+};
 
 use shrs::prelude::*;
 
@@ -22,18 +26,18 @@ impl Lang for MuxLang {
         ctx: &mut Context,
         rt: &mut Runtime,
         cmd: String,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<CmdOutput> {
         let lang_name = match ctx.state.get::<MuxState>() {
             Some(state) => &state.lang,
-            None => return Ok(()),
+            None => return Ok(CmdOutput::empty()),
         };
         // TODO maybe return error if we can't find a lang
 
         if let Some(lang) = self.langs.get(lang_name) {
-            lang.eval(sh, ctx, rt, cmd);
+            return lang.eval(sh, ctx, rt, cmd);
         }
 
-        Ok(())
+        Ok(CmdOutput::empty())
     }
 
     fn name(&self) -> String {
@@ -60,12 +64,15 @@ impl Lang for NuLang {
         ctx: &mut Context,
         rt: &mut Runtime,
         cmd: String,
-    ) -> shrs::anyhow::Result<()> {
-        let mut handle = Command::new("nu").args(vec!["-c", &cmd]).spawn()?;
+    ) -> shrs::anyhow::Result<CmdOutput> {
+        let mut handle = Command::new("nu")
+            .args(vec!["-c", &cmd])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let output = handle.wait_with_output()?;
 
-        handle.wait()?;
-
-        Ok(())
+        Ok(CmdOutput::from_process_output(output))
     }
 
     fn name(&self) -> String {
@@ -92,12 +99,15 @@ impl Lang for PythonLang {
         ctx: &mut Context,
         rt: &mut Runtime,
         cmd: String,
-    ) -> shrs::anyhow::Result<()> {
-        let mut handle = Command::new("python").args(vec!["-c", &cmd]).spawn()?;
+    ) -> shrs::anyhow::Result<CmdOutput> {
+        let mut handle = Command::new("python3")
+            .args(vec!["-c", &cmd])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let output = handle.wait_with_output()?;
 
-        handle.wait()?;
-
-        Ok(())
+        Ok(CmdOutput::from_process_output(output))
     }
 
     fn name(&self) -> String {
@@ -124,24 +134,15 @@ impl Lang for BashLang {
         ctx: &mut Context,
         rt: &mut Runtime,
         cmd: String,
-    ) -> shrs::anyhow::Result<()> {
-        let mut handle = Command::new("bash").args(vec!["-c", &cmd]).spawn()?;
+    ) -> shrs::anyhow::Result<CmdOutput> {
+        let mut handle = Command::new("bash")
+            .args(vec!["-c", &cmd])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        let output = handle.wait_with_output()?;
 
-        let exit_status = handle.wait()?;
-
-        // TODO make this generic across all languages later
-        let _ = sh.hooks.run(
-            sh,
-            ctx,
-            rt,
-            AfterCommandCtx {
-                command: cmd.clone(),
-                exit_code: exit_status.code().unwrap_or(0), // default to exit code zero
-                cmd_output: String::new(),                  // TODO
-            },
-        );
-
-        Ok(())
+        Ok(CmdOutput::from_process_output(output))
     }
 
     fn name(&self) -> String {

--- a/plugins/shrs_output_capture/src/builtin.rs
+++ b/plugins/shrs_output_capture/src/builtin.rs
@@ -20,7 +20,7 @@ impl BuiltinCmd for AgainBuiltin {
         _args: &Vec<String>,
     ) -> anyhow::Result<BuiltinStatus> {
         if let Some(state) = ctx.state.get::<OutputCaptureState>() {
-            print!("{}", state.last_command);
+            print!("{}", state.last_output.out());
         }
 
         Ok(BuiltinStatus::success())

--- a/plugins/shrs_output_capture/src/builtin.rs
+++ b/plugins/shrs_output_capture/src/builtin.rs
@@ -20,7 +20,8 @@ impl BuiltinCmd for AgainBuiltin {
         _args: &Vec<String>,
     ) -> anyhow::Result<BuiltinStatus> {
         if let Some(state) = ctx.state.get::<OutputCaptureState>() {
-            print!("{}", state.last_output.out());
+            print!("stdout: {}", state.last_output.stdout);
+            print!("stderr: {}", state.last_output.stderr);
         }
 
         Ok(BuiltinStatus::success())

--- a/plugins/shrs_output_capture/src/lib.rs
+++ b/plugins/shrs_output_capture/src/lib.rs
@@ -15,7 +15,7 @@ struct OutputCaptureState {
 impl OutputCaptureState {
     pub fn new() -> Self {
         OutputCaptureState {
-            last_output: CmdOutput::new("".to_string(), "".to_string(), ExitStatus::from_raw(0)),
+            last_output: CmdOutput::new(String::new(), String::new(), ExitStatus::from_raw(0)),
         }
     }
 }

--- a/plugins/shrs_output_capture/src/lib.rs
+++ b/plugins/shrs_output_capture/src/lib.rs
@@ -3,17 +3,19 @@
 //!
 mod builtin;
 
+use std::{os::unix::process::ExitStatusExt, process::ExitStatus};
+
 use builtin::AgainBuiltin;
 use shrs::prelude::*;
 
 struct OutputCaptureState {
-    pub last_command: String,
+    pub last_output: CmdOutput,
 }
 
 impl OutputCaptureState {
     pub fn new() -> Self {
         OutputCaptureState {
-            last_command: String::new(),
+            last_output: CmdOutput::new("".to_string(), "".to_string(), ExitStatus::from_raw(0)),
         }
     }
 }
@@ -37,7 +39,7 @@ fn after_command_hook(
     ctx: &AfterCommandCtx,
 ) -> anyhow::Result<()> {
     if let Some(state) = sh_ctx.state.get_mut::<OutputCaptureState>() {
-        state.last_command = ctx.cmd_output.clone();
+        state.last_output = ctx.cmd_output.clone();
     }
     Ok(())
 }


### PR DESCRIPTION
Adds CmdOutput to return output from Lang eval along with status code

- Extracted AfterCmdCtx calls from Bash, made eval return output, without the child process automatically printing 
- Removed Jobs ExitStatus and opted to use process::ExitStatus, not sure if this is the right thing to do but it offers all the same functionality and no need for conversion.
- Custom CmdOutput just so that out and err can be passed as strings
- Still need to figure out how to return output from posixlang
- Builtin commands also need AfterCmdCtx to run after so need to have them return output instead of printing on their own, and then outputting them in a standardised way so that it can also be customised ( error highlighting)