### PR TITLE
reading from stdout and stdin

### DIFF
--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -223,13 +223,6 @@ fn run_shell(
             let output = sh.lang.eval(sh, ctx, rt, line.clone());
             match output {
                 Ok(cmd_output) => {
-                    // if !cmd_output.stdout.is_empty() {
-                    //     print!("{}", cmd_output.stdout);
-                    // }
-                    // if !cmd_output.stderr.is_empty() {
-                    //     eprint!("{}", cmd_output.stderr);
-                    // }
-
                     let _ = sh.hooks.run(
                         sh,
                         ctx,
@@ -252,7 +245,7 @@ fn run_shell(
 
         for status in exit_statuses.into_iter() {
             sh.hooks
-                .run::<JobExitCtx>(sh, ctx, rt, JobExitCtx { status });
+                .run::<JobExitCtx>(sh, ctx, rt, JobExitCtx { status })?;
         }
     }
 }

--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -223,12 +223,12 @@ fn run_shell(
             let output = sh.lang.eval(sh, ctx, rt, line.clone());
             match output {
                 Ok(cmd_output) => {
-                    if !cmd_output.stdout.is_empty() {
-                        print!("{}", cmd_output.stdout);
-                    }
-                    if !cmd_output.stderr.is_empty() {
-                        eprint!("{}", cmd_output.stderr);
-                    }
+                    // if !cmd_output.stdout.is_empty() {
+                    //     print!("{}", cmd_output.stdout);
+                    // }
+                    // if !cmd_output.stderr.is_empty() {
+                    //     eprint!("{}", cmd_output.stderr);
+                    // }
 
                     let _ = sh.hooks.run(
                         sh,

--- a/plugins/shrs_mux/src/interpreter.rs
+++ b/plugins/shrs_mux/src/interpreter.rs
@@ -1,0 +1,50 @@
+use std::{
+    io::{BufRead, BufReader},
+    process::{Child, ChildStderr, ChildStdout},
+    sync::{Arc, Mutex},
+};
+
+pub fn read_out(instance: Arc<Mutex<Child>>) -> shrs::anyhow::Result<(String, i32)> {
+    let mut output = String::new();
+    let exit_status: i32;
+    loop {
+        let mut guard = instance.lock().unwrap();
+        let mut reader = BufReader::new(guard.stderr.as_mut().expect("Failed to open stderr"));
+
+        let mut line = String::new();
+
+        reader.read_line(&mut line)?;
+        println!("vyv{}", line.clone());
+
+        if line.contains("\x1a") {
+            let s: String = line.chars().filter(|c| c.is_numeric()).collect();
+            exit_status = s.parse::<i32>()?;
+            break;
+        }
+
+        output.push_str(line.as_str());
+    }
+    Ok((output, exit_status))
+}
+
+pub fn read_err(instance: Arc<Mutex<Child>>) -> shrs::anyhow::Result<String> {
+    let mut output = String::new();
+    loop {
+        let mut guard = instance.lock().unwrap();
+
+        let mut reader = BufReader::new(guard.stderr.as_mut().expect("Failed to open stderr"));
+
+        let mut line = String::new();
+
+        reader.read_line(&mut line)?;
+
+        println!("err{}", line.clone());
+
+        if line.contains("\x1a") {
+            break;
+        }
+
+        output.push_str(line.as_str());
+    }
+    Ok(output)
+}

--- a/plugins/shrs_mux/src/interpreter.rs
+++ b/plugins/shrs_mux/src/interpreter.rs
@@ -1,48 +1,37 @@
 use std::{
     io::{BufRead, BufReader},
-    process::{Child, ChildStderr, ChildStdout},
-    sync::{Arc, Mutex},
+    process::{ChildStderr, ChildStdout},
 };
 
-pub fn read_out(instance: Arc<Mutex<Child>>) -> shrs::anyhow::Result<(String, i32)> {
+pub fn read_out(mut reader: BufReader<&mut ChildStdout>) -> shrs::anyhow::Result<(String, i32)> {
     let mut output = String::new();
-    let exit_status: i32;
     loop {
-        let mut guard = instance.lock().unwrap();
-        let mut reader = BufReader::new(guard.stderr.as_mut().expect("Failed to open stderr"));
-
         let mut line = String::new();
 
         reader.read_line(&mut line)?;
-        println!("vyv{}", line.clone());
 
         if line.contains("\x1a") {
-            let s: String = line.chars().filter(|c| c.is_numeric()).collect();
-            exit_status = s.parse::<i32>()?;
-            break;
+            let exit_status: String = line.chars().filter(|c| c.is_numeric()).collect();
+
+            return Ok((output, exit_status.parse::<i32>()?));
         }
+        print!("{}", line);
 
         output.push_str(line.as_str());
     }
-    Ok((output, exit_status))
 }
 
-pub fn read_err(instance: Arc<Mutex<Child>>) -> shrs::anyhow::Result<String> {
+pub fn read_err(mut reader: BufReader<&mut ChildStderr>) -> shrs::anyhow::Result<String> {
     let mut output = String::new();
     loop {
-        let mut guard = instance.lock().unwrap();
-
-        let mut reader = BufReader::new(guard.stderr.as_mut().expect("Failed to open stderr"));
-
         let mut line = String::new();
 
         reader.read_line(&mut line)?;
 
-        println!("err{}", line.clone());
-
         if line.contains("\x1a") {
             break;
         }
+        eprint!("{}", line);
 
         output.push_str(line.as_str());
     }

--- a/plugins/shrs_mux/src/lang.rs
+++ b/plugins/shrs_mux/src/lang.rs
@@ -1,7 +1,9 @@
 use std::{
+    cell::RefCell,
     collections::HashMap,
-    io::Read,
-    process::{Command, ExitStatus, Stdio},
+    io::{BufRead, BufReader, Read, Write},
+    ops::Add,
+    process::{Child, Command, ExitStatus, Stdio},
 };
 
 use shrs::prelude::*;
@@ -119,11 +121,22 @@ impl Lang for PythonLang {
     }
 }
 
-pub struct BashLang {}
+pub struct BashLang {
+    pub instance: RefCell<Child>,
+}
 
 impl BashLang {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            instance: RefCell::new(
+                Command::new("bash")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                    .expect("Failed to start bash lol"),
+            ),
+        }
     }
 }
 
@@ -135,14 +148,55 @@ impl Lang for BashLang {
         rt: &mut Runtime,
         cmd: String,
     ) -> shrs::anyhow::Result<CmdOutput> {
-        let mut handle = Command::new("bash")
-            .args(vec!["-c", &cmd])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-        let output = handle.wait_with_output()?;
+        let mut instance = self.instance.borrow_mut();
+        let stdin = instance.stdin.as_mut().expect("Failed to open stdin");
+        // stdin
+        //     .write_all(cmd.as_bytes())
+        //     .expect("Failed to write to stdin");
 
-        Ok(CmdOutput::from(output))
+        //idk how to echo to stdout and stderr
+        stdin
+            .write_all((cmd + ";echo '\x1A'; echo '\x1A' >&2\n").as_bytes())
+            .expect("Failed to send Ctrl+C to stdin");
+
+        let mut stdout_reader =
+            BufReader::new(instance.stdout.as_mut().expect("Failed to open stdout"));
+
+        let mut stdout = String::new();
+        loop {
+            let mut line = String::new();
+
+            stdout_reader.read_line(&mut line)?;
+            dbg!(line.clone());
+
+            if line.contains("\x1a") {
+                break;
+            }
+
+            stdout.push_str(line.as_str());
+        }
+
+        let mut stderr_reader =
+            BufReader::new(instance.stderr.as_mut().expect("Failed to open stdout"));
+
+        let mut stderr = String::new();
+        loop {
+            let mut line = String::new();
+
+            stderr_reader.read_line(&mut line)?;
+
+            dbg!(line.clone());
+
+            if line.contains("\x1a") {
+                break;
+            }
+
+            stderr.push_str(line.as_str());
+        }
+
+        // println!("{}", stdout.trim_end_matches("\n"));
+
+        Ok(CmdOutput::empty())
     }
 
     fn name(&self) -> String {

--- a/plugins/shrs_mux/src/lib.rs
+++ b/plugins/shrs_mux/src/lib.rs
@@ -1,4 +1,5 @@
 mod builtin;
+mod interpreter;
 mod lang;
 
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
This pr attempts to make bash persistent #247. Output is also realtime as long as only stdout or stderr are outputting.
Implementation Notes:
- The process is stored in a refcell since self cannot be made mutable.
- A bufreader must be used to read from it now because bash will not respond if .wait() is not called in the other method. .wait() closes stdin which means the next eval that is called will panic.
- An eof character is outputted to stdout and stderr which determines when all output is given. 
- The exit status is also returned with the $? command.