### PR TITLE
update env and wd in bash

### DIFF
--- a/crates/shrs_core/src/shell.rs
+++ b/crates/shrs_core/src/shell.rs
@@ -104,10 +104,8 @@ pub fn set_working_dir(
         .set("OLDPWD", old_path_str)
         .expect("failed setting env var");
 
-    let path_str = path.to_str().expect("failed converting to str");
-    rt.env
-        .set("PATH", path_str)
-        .expect("failed setting env var");
+    let pwd = path.to_str().expect("failed converting to str");
+    rt.env.set("PWD", pwd).expect("failed setting env var");
     rt.working_dir = path.clone();
 
     // Set process working directory too


### PR DESCRIPTION
Bash pwd is updated in eval as well as env vars. Updating with hook is too convoluted, so this approach is better.

Also set_working_dir changed path instead of pwd, now fixed.
TODO:
- Update env vars after bash call
- change working directory after bash call