### PR TITLE
Fix misc bugs

### DIFF
--- a/crates/shrs_core/src/env.rs
+++ b/crates/shrs_core/src/env.rs
@@ -82,7 +82,7 @@ impl Env {
             return Err(EnvError::InvalidValue(val.into()));
         }
 
-        // env::set_var(var.to_ascii_uppercase(), val);
+        env::set_var(var, val);
         self.var_table.insert(var.into(), val.into());
         Ok(())
     }
@@ -100,7 +100,7 @@ impl Env {
         if key_sanitation(var) {
             return Err(EnvError::InvalidKey(var.into()));
         }
-        // env::remove_var(var);
+        env::remove_var(var);
         self.var_table.remove(var);
         Ok(())
     }

--- a/crates/shrs_core/src/shell.rs
+++ b/crates/shrs_core/src/shell.rs
@@ -92,10 +92,14 @@ pub fn set_working_dir(
     run_hook: bool,
 ) -> anyhow::Result<()> {
     // Check working directory validity
-    let path = PathBuf::from(wd);
-    if !path.is_dir() {
+    let path = if let Ok(path) = PathBuf::from(wd).canonicalize() {
+        if !path.is_dir() {
+            return Err(anyhow!("Invalid path"));
+        }
+        path
+    } else {
         return Err(anyhow!("Invalid path"));
-    }
+    };
 
     // Save old working directory
     let old_path = get_working_dir(rt).to_path_buf();

--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -4,7 +4,7 @@ BOLD='\033[1;36m'
 NC='\033[0m'
 printf "${BOLD}[PRE-COMMIT]${NC} formatting code...\n"
 cargo +nightly fmt --all
-git add -u
+
 # printf "${BOLD}[PRE-COMMIT]${NC} linting...\n"
 # cargo clippy
 

--- a/plugins/shrs_derive_completion/src/lib.rs
+++ b/plugins/shrs_derive_completion/src/lib.rs
@@ -59,7 +59,7 @@ fn impl_struct(item: ItemStruct) -> Result<proc_macro2::TokenStream, Error> {
     let mut flags: Vec<Flag> = vec![];
 
     let struct_name = &item.ident;
-    cli.name(struct_name.as_display().to_string().to_ascii_lowercase());
+    cli.name(struct_name.to_string().to_ascii_lowercase());
 
     for field in item.fields.iter() {
         let field_name = field.ident.clone().ok_or(Error::UnnamedField)?;


### PR DESCRIPTION
# Description of Changes
FIxes the following:
- `env.set` and `remove` now actually sets and removes env in process level. This also fixes env vars not being updated by `export`
- prevent unstaged files from being committed. The pre-commit actually staged everything before linting which lead to this.
- remove use of non-existant api.