### PR TITLE
Fixes #230 by adding `f/F/t/T`

### DIFF
--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -703,10 +703,7 @@ impl Line {
             },
             // fill prompt with history element
             HistoryInd::Line(i) => {
-                let history_item = self
-                    .history
-                    .get(i)
-                    .expect(&format!("i: {i} limit: {}", self.history.len()));
+                let history_item = self.history.get(i).unwrap();
                 ctx.cb.clear();
                 ctx.cb.insert(Location::Cursor(), history_item)?;
             },

--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -93,7 +93,7 @@ impl Default for Line {
 }
 
 /// State for where the prompt is in history browse mode
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum HistoryInd {
     /// Brand new prompt
     Prompt,
@@ -112,7 +112,7 @@ impl HistoryInd {
                     HistoryInd::Line(0)
                 }
             },
-            HistoryInd::Line(i) => HistoryInd::Line((i + 1).min(limit)),
+            HistoryInd::Line(i) => HistoryInd::Line((i + 1).min(limit - 1)),
         }
     }
 
@@ -703,7 +703,10 @@ impl Line {
             },
             // fill prompt with history element
             HistoryInd::Line(i) => {
-                let history_item = self.history.get(i).unwrap();
+                let history_item = self
+                    .history
+                    .get(i)
+                    .expect(&format!("i: {i} limit: {}", self.history.len()));
                 ctx.cb.clear();
                 ctx.cb.insert(Location::Cursor(), history_item)?;
             },

--- a/crates/shrs_vi/src/ast.rs
+++ b/crates/shrs_vi/src/ast.rs
@@ -18,7 +18,14 @@ pub enum Motion {
     End,
     /// Select entire line (for Move action this behaves same as End)
     All,
-    Find(char),
+    /// Search forward/backward for/to character
+    ///
+    /// Encapsulates `f`, `F`, `t`, and `T`
+    Find {
+        ch: char,
+        back: bool,
+        to: bool,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/shrs_vi/src/grammar.lalrpop
+++ b/crates/shrs_vi/src/grammar.lalrpop
@@ -21,7 +21,10 @@ pub Motion: Motion = {
     "$" => Motion::End,
     "^" => Motion::Start,
     "0" => Motion::Start, // currently implementing 0 as same as ^
-    "f" <c:r"[a-zA-Z]"> => Motion::Find(c.chars().next().unwrap()),
+    "f" <c:r"[a-zA-Z]"> => Motion::Find { ch: c.chars().next().unwrap(), back: false, to: false },
+    "F" <c:r"[a-zA-Z]"> => Motion::Find { ch: c.chars().next().unwrap(), back: true, to: false },
+    "t" <c:r"[a-zA-Z]"> => Motion::Find { ch: c.chars().next().unwrap(), back: false, to: true},
+    "T" <c:r"[a-zA-Z]"> => Motion::Find { ch: c.chars().next().unwrap(), back: true, to: true },
 };
 
 pub Action: Action = {


### PR DESCRIPTION
While `f` was already implemented, this PR implements the rest of them. I have not yet figured out how to test them, thence the draft.

Rather than adding `Motion::FindBack`, `FindTo`, and `FindToBack`, I modified `Motion::Find` to be `Find { ch: char, back: bool, to: bool }`, and updated the appropriate logic.