### PR TITLE
insert plugin struct into state on init

### DIFF
--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -115,6 +115,9 @@ impl ShellConfig {
                         plugin_meta.name, e
                     ),
                 }
+            } else {
+                // success
+                self.state.insert(plugin);
             }
         }
 

--- a/plugins/shrs_analytics/examples/basic.rs
+++ b/plugins/shrs_analytics/examples/basic.rs
@@ -3,7 +3,7 @@ use shrs_analytics::AnalyticsPlugin;
 
 fn main() {
     let myshell = ShellBuilder::default()
-        .with_plugin(AnalyticsPlugin)
+        .with_plugin(AnalyticsPlugin::new())
         .build()
         .unwrap();
 

--- a/plugins/shrs_analytics/src/builtin.rs
+++ b/plugins/shrs_analytics/src/builtin.rs
@@ -1,6 +1,6 @@
 use shrs::{anyhow::Result, prelude::*};
 
-use crate::AnalyticsState;
+use crate::AnalyticsPlugin;
 
 pub struct AnalyticsBuiltin;
 
@@ -16,7 +16,7 @@ impl BuiltinCmd for AnalyticsBuiltin {
         //which metric
         const LIMIT: usize = 5;
 
-        ctx.state.get::<AnalyticsState>().map(|state| {
+        ctx.state.get::<AnalyticsPlugin>().map(|state| {
             ctx.out.println("most used commands ====").unwrap();
             let mut commands = state.commands.iter().collect::<Vec<_>>();
             commands.sort_by(|a, b| b.cmp(a));

--- a/plugins/shrs_analytics/src/lib.rs
+++ b/plugins/shrs_analytics/src/lib.rs
@@ -18,28 +18,26 @@ mod builtin;
 
 // Hooks to collect analytics
 
-pub struct AnalyticsState {
+pub struct AnalyticsPlugin {
     commands: HashMap<String, u32>,
     dirs: HashMap<PathBuf, u32>,
 }
 
-impl AnalyticsState {
+impl AnalyticsPlugin {
     pub fn new() -> Self {
-        AnalyticsState {
+        AnalyticsPlugin {
             commands: HashMap::new(),
             dirs: HashMap::new(),
         }
     }
 }
 
-pub struct AnalyticsPlugin;
-
 impl Plugin for AnalyticsPlugin {
     fn init(&self, shell: &mut ShellConfig) -> Result<()> {
         shell.builtins.insert("analytics", AnalyticsBuiltin);
         shell.hooks.register(record_dir_change);
         shell.hooks.register(most_common_commands);
-        shell.state.insert(AnalyticsState::new());
+        shell.state.insert(AnalyticsPlugin::new());
 
         Ok(())
     }
@@ -61,7 +59,7 @@ fn most_common_commands(
     cmd_ctx: &BeforeCommandCtx,
 ) -> anyhow::Result<()> {
     // TODO maybe read commands from history too?
-    ctx.state.get_mut::<AnalyticsState>().map(|state| {
+    ctx.state.get_mut::<AnalyticsPlugin>().map(|state| {
         // add to most used commands
 
         // TODO IFS


### PR DESCRIPTION
Previously if you wanted to add any form of configuration to a plugin, you would have to add a field to the plugin struct, then on initialization, create another struct with the field duplicated, copy the field over and insert the state. This was obviously really annoying, so now by default shrs will insert the plugin into state directly. This also provides a way to check if a plugin is installed to some extent