### PR TITLE
Help builtin command list out keybindings

### DIFF
--- a/crates/shrs_core/src/builtin/help.rs
+++ b/crates/shrs_core/src/builtin/help.rs
@@ -22,6 +22,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Builtin,
+    Bindings,
 }
 
 #[derive(Default)]
@@ -39,18 +40,20 @@ impl BuiltinCmd for HelpBuiltin {
         match &cli.command {
             Commands::Builtin => {
                 let cmds = sh.builtins.builtins.keys();
-                let info = sh.keybinding.get_info();
 
-                ctx.out.println("Builtin Commands:")?;
+                ctx.out.println("Builtin Commands")?;
 
                 for cmd in cmds {
                     ctx.out.println(cmd)?;
                 }
+            },
+            Commands::Bindings => {
+                let info = sh.keybinding.get_info();
 
-                ctx.out.println("")?;
-                ctx.out.println("Key Bindings:")?;
-                for binding in info.keys() {
-                    ctx.out.println(binding)?;
+                ctx.out.println("Key Bindings")?;
+
+                for (binding, desc) in info {
+                    ctx.out.println(format!("{}: {}", binding, desc))?;
                 }
             },
         }

--- a/crates/shrs_core/src/builtin/help.rs
+++ b/crates/shrs_core/src/builtin/help.rs
@@ -39,11 +39,18 @@ impl BuiltinCmd for HelpBuiltin {
         match &cli.command {
             Commands::Builtin => {
                 let cmds = sh.builtins.builtins.keys();
+                let info = sh.keybinding.get_info();
 
-                ctx.out.println("Builtin Commands")?;
+                ctx.out.println("Builtin Commands:")?;
 
                 for cmd in cmds {
                     ctx.out.println(cmd)?;
+                }
+
+                ctx.out.println("")?;
+                ctx.out.println("Key Bindings:")?;
+                for binding in info.keys() {
+                    ctx.out.println(binding)?;
                 }
             },
         }

--- a/crates/shrs_core/src/keybinding.rs
+++ b/crates/shrs_core/src/keybinding.rs
@@ -19,6 +19,7 @@ pub trait Keybinding {
         rt: &mut Runtime,
         key_event: KeyEvent,
     ) -> bool;
+    fn get_info(&self) -> &HashMap<String, String>;
 }
 
 pub type Binding = (KeyCode, KeyModifiers);
@@ -27,7 +28,7 @@ pub type Binding = (KeyCode, KeyModifiers);
 #[macro_export]
 macro_rules! keybindings {
     // TODO temp hacky macro
-    (|$sh:ident, $ctx:ident, $rt:ident| $($binding:expr => $func:block),* $(,)*) => {{
+    (|$sh:ident, $ctx:ident, $rt:ident| $($binding:expr => ($func:block, $desc:expr)),* $(,)*) => {{
         use $crate::keybinding::{DefaultKeybinding, parse_keybinding, BindingFn};
         use $crate::prelude::{Shell, Context, Runtime};
         DefaultKeybinding::from_iter([
@@ -35,7 +36,9 @@ macro_rules! keybindings {
                 parse_keybinding($binding).unwrap(),
                 Box::new(|$sh: &Shell, $ctx: &mut Context, $rt: &mut Runtime| {
                     $func;
-                }) as Box<BindingFn>
+                }) as Box<BindingFn>,
+                $binding.to_string(),
+                $desc.to_string(),
             )),*
         ])
     }};
@@ -110,13 +113,15 @@ fn parse_modifier(s: &str) -> Result<KeyModifiers, BindingFromStrError> {
 /// Default implementation of [Keybinding]
 pub struct DefaultKeybinding {
     // TODO this can't take closure right now
-    pub bindings: HashMap<Binding, Box<BindingFn>>,
+    pub bindings: HashMap<Binding, (Box<BindingFn>)>,
+    pub info: HashMap<String, String>,
 }
 
 impl DefaultKeybinding {
     pub fn new() -> Self {
         Self {
             bindings: HashMap::new(),
+            info: HashMap::new(),
         }
     }
 }
@@ -138,13 +143,25 @@ impl Keybinding for DefaultKeybinding {
         }
         event_handled
     }
+
+    fn get_info(&self) -> &HashMap<String, String> {
+        &self.info
+    }
 }
 
-impl FromIterator<(Binding, Box<BindingFn>)> for DefaultKeybinding {
-    fn from_iter<T: IntoIterator<Item = (Binding, Box<BindingFn>)>>(iter: T) -> Self {
-        DefaultKeybinding {
-            bindings: HashMap::from_iter(iter),
+impl FromIterator<(Binding, Box<BindingFn>, String, String)> for DefaultKeybinding {
+    fn from_iter<T: IntoIterator<Item = (Binding, Box<BindingFn>, String, String)>>(
+        iter: T,
+    ) -> Self {
+        let mut default_keybinding = DefaultKeybinding {
+            bindings: HashMap::new(),
+            info: HashMap::new(),
+        };
+        for item in iter {
+            default_keybinding.bindings.insert(item.0, item.1);
+            default_keybinding.info.insert(item.2, item.3);
         }
+        default_keybinding
     }
 }
 

--- a/crates/shrs_core/src/keybinding.rs
+++ b/crates/shrs_core/src/keybinding.rs
@@ -28,7 +28,7 @@ pub type Binding = (KeyCode, KeyModifiers);
 #[macro_export]
 macro_rules! keybindings {
     // TODO temp hacky macro
-    (|$sh:ident, $ctx:ident, $rt:ident| $($binding:expr => ($func:block, $desc:expr)),* $(,)*) => {{
+    (|$sh:ident, $ctx:ident, $rt:ident| $($binding:expr => ($desc:expr, $func:block)),* $(,)*) => {{
         use $crate::keybinding::{DefaultKeybinding, parse_keybinding, BindingFn};
         use $crate::prelude::{Shell, Context, Runtime};
         DefaultKeybinding::from_iter([

--- a/docs/content/docs/shell-config/keybindings.md
+++ b/docs/content/docs/shell-config/keybindings.md
@@ -21,14 +21,16 @@ internal detail and not very fun to write, so a macro is provided to make the
 experience a bit better.
 ```rust
 let keybinding = keybindings! {
-    "C-l" => Command::new("clear").spawn(),
+    |sh, ctx, rt|
+    "C-l" => ("Clear the screen", { Command::new("clear").spawn() }),
 };
 
 myshell.with_keybinding(keybinding);
 ```
 
-The macro allows us to represent key combinations in terms of strings. You can
-also include modifier keys (such as control and shift). Here are the supported modifiers:
+`sh`, `ctx`, and `rt` are shell, context, and runtime variables respectively. Each keybinding is matched with a tuple. The first item in the tuple is a description of what the keybinding performs. The second item in the tuple is the function that will be executed once that key combination is pressed.
+
+The macro allows us to represent key combinations in terms of strings. You can also include modifier keys (such as control and shift). Here are the supported modifiers:
 
 | Modifier | Usage |
 | ---|--- |

--- a/docs/content/docs/shell-config/keybindings.md
+++ b/docs/content/docs/shell-config/keybindings.md
@@ -20,7 +20,7 @@ when `Control+L` is pressed. How keybindings are represented is a bit more of an
 internal detail and not very fun to write, so a macro is provided to make the
 experience a bit better.
 ```rust
-ley keybinding = keybindings! {
+let keybinding = keybindings! {
     "C-l" => Command::new("clear").spawn(),
 };
 

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -105,21 +105,21 @@ fn main() {
     // Add basic keybindings
     let keybinding = keybindings! {
         |sh, ctx, rt|
-        "C-l" => { Command::new("clear").spawn() },
-        "C-p" => {
+        "C-l" => ({ Command::new("clear").spawn()}, "Clear screen"),
+        "C-p" => ({
             if let Some(state) = ctx.state.get_mut::<CdStackState>() {
                 if let Some(new_path) = state.down() {
                     set_working_dir(sh, ctx, rt, &new_path, false).unwrap();
                 }
             }
-        },
-        "C-n" => {
+        }, "Move up one in the command history"),
+        "C-n" => ({
             if let Some(state) = ctx.state.get_mut::<CdStackState>() {
                 if let Some(new_path) = state.up() {
                     set_working_dir(sh, ctx, rt, &new_path, false).unwrap();
                 }
             }
-        },
+        }, "Move down one in the command history"),
     };
 
     // =-=-= Prompt =-=-=

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -105,21 +105,21 @@ fn main() {
     // Add basic keybindings
     let keybinding = keybindings! {
         |sh, ctx, rt|
-        "C-l" => ({ Command::new("clear").spawn()}, "Clear screen"),
-        "C-p" => ({
+        "C-l" => ("Clear the screen", { Command::new("clear").spawn()}),
+        "C-p" => ("Move up one in the command history", {
             if let Some(state) = ctx.state.get_mut::<CdStackState>() {
                 if let Some(new_path) = state.down() {
                     set_working_dir(sh, ctx, rt, &new_path, false).unwrap();
                 }
             }
-        }, "Move up one in the command history"),
-        "C-n" => ({
+        }),
+        "C-n" => ("Move down one in the command history", {
             if let Some(state) = ctx.state.get_mut::<CdStackState>() {
                 if let Some(new_path) = state.up() {
                     set_working_dir(sh, ctx, rt, &new_path, false).unwrap();
                 }
             }
-        }, "Move down one in the command history"),
+        }),
     };
 
     // =-=-= Prompt =-=-=


### PR DESCRIPTION
## Summary of Changes

The command `help builtin` now also displays a list of key bindings. Screenshot included below.

![shrs1](https://github.com/MrPicklePinosaur/shrs/assets/47926823/613b02fe-bdf7-4f47-89db-5f21f4b56c48)

## Implementation Details

Added a new hash map with key bindings as keys and a short description as value. The description could be used in the future if needed.

Closes #208 

