### PR TITLE
Moving StyledBuf 

### DIFF
--- a/crates/shrs/Cargo.toml
+++ b/crates/shrs/Cargo.toml
@@ -35,6 +35,7 @@ shrs_core = { path = "../shrs_core", version = "^0.0.2" }
 shrs_line = { path = "../shrs_line", version = "^0.0.2" }
 shrs_lang = { path = "../shrs_lang", version = "^0.0.2" }
 shrs_job = { path = "../shrs_job", version = "^0.0.2" }
+shrs_utils = { path = "../shrs_utils", version = "^0.0.2" }
 
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/crates/shrs/src/lib.rs
+++ b/crates/shrs/src/lib.rs
@@ -60,6 +60,7 @@ pub mod prelude {
     pub use shrs_core::prelude::*;
     pub use shrs_lang::PosixLang;
     pub use shrs_line::prelude::*;
+    pub use shrs_utils::*;
 
     pub use crate::{anyhow, crossterm, crossterm::*, plugin::*, shell::*};
 }

--- a/crates/shrs_core/src/output_writer.rs
+++ b/crates/shrs_core/src/output_writer.rs
@@ -3,7 +3,11 @@ use std::{
     io::{stderr, stdout, BufWriter, Write},
 };
 
-use crossterm::{style::Print, QueueableCommand};
+use crossterm::{
+    style::{Print, PrintStyledContent},
+    QueueableCommand,
+};
+use shrs_utils::styled_buf::StyledBuf;
 
 pub struct OutputWriter {
     stdout: BufWriter<std::io::Stdout>,
@@ -58,5 +62,19 @@ impl OutputWriter {
     pub fn end_collecting(&mut self) -> (String, String) {
         self.collecting = false;
         (self.out.drain(..).collect(), self.err.drain(..).collect())
+    }
+    pub fn print_buf(&mut self, buf: StyledBuf) -> anyhow::Result<()> {
+        let lines = buf.lines();
+
+        for (i, line) in lines.iter().enumerate() {
+            if i > 0 {
+                self.print("\r\n")?;
+            }
+            for span in line {
+                self.stdout.queue(PrintStyledContent(span.clone()))?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/shrs_core/src/theme.rs
+++ b/crates/shrs_core/src/theme.rs
@@ -43,9 +43,3 @@ impl Default for Theme {
         }
     }
 }
-struct SyntaxTheme {
-    pub command: Color,
-    pub args: Color,
-    pub path: Color,
-    pub env_var: Color,
-}

--- a/crates/shrs_line/src/highlight.rs
+++ b/crates/shrs_line/src/highlight.rs
@@ -4,8 +4,7 @@ use std::{collections::HashMap, default, usize};
 
 use crossterm::style::{Color, ContentStyle};
 use shrs_lang::{Lexer, Token};
-
-use crate::painter::StyledBuf;
+use shrs_utils::styled_buf::StyledBuf;
 
 pub trait Highlighter {
     fn highlight(&self, buf: &str, begin: usize) -> StyledBuf;

--- a/crates/shrs_line/src/lib.rs
+++ b/crates/shrs_line/src/lib.rs
@@ -43,9 +43,7 @@ pub mod prelude {
         hooks::*,
         line::{Line, LineBuilder, LineBuilderError, LineCtx, LineMode, Readline},
         menu::{DefaultMenu, Menu},
-        painter::StyledBuf,
         prompt::{DefaultPrompt, Prompt, *},
-        styled,
         vi::*,
     };
 }

--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -17,6 +17,7 @@ use shrs_lang::{Lexer, Token};
 use shrs_utils::{
     algo::longest_common_prefix,
     cursor_buffer::{CursorBuffer, Location},
+    styled_buf::StyledBuf,
 };
 use shrs_vi::{Action, Command, Motion, Parser};
 use trie_rs::TrieBuilder;

--- a/crates/shrs_line/src/prompt.rs
+++ b/crates/shrs_line/src/prompt.rs
@@ -1,8 +1,9 @@
 //! Shell prompt
 
 use crossterm::style::{ContentStyle, StyledContent};
+use shrs_utils::styled_buf::StyledBuf;
 
-use crate::{line::LineCtx, painter::StyledBuf};
+use crate::line::LineCtx;
 
 /// Implement this trait to create your own prompt
 pub trait Prompt {
@@ -30,102 +31,5 @@ impl Prompt for DefaultPrompt {
 
     fn prompt_right(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
         StyledBuf::from_iter(vec![])
-    }
-}
-
-fn default_styled_content(s: String) -> StyledContent<String> {
-    StyledContent::new(ContentStyle::default(), s)
-}
-/// Valid types that can be passed to the styled macro
-// cool since anyone can implement this trait to add something else that can be passed to this
-// macro
-pub trait StyledDisplay {
-    fn render(&self) -> StyledContent<String>;
-}
-impl<T: ToString> StyledDisplay for Option<T> {
-    fn render(&self) -> StyledContent<String> {
-        let styled = self
-            .as_ref()
-            .to_owned()
-            .map(|x| x.to_string())
-            .unwrap_or_default();
-        default_styled_content(styled)
-    }
-}
-impl<T: ToString, E> StyledDisplay for Result<T, E> {
-    fn render(&self) -> StyledContent<String> {
-        let styled = self
-            .as_ref()
-            .to_owned()
-            .map(|x| x.to_string())
-            .unwrap_or_default();
-        default_styled_content(styled)
-    }
-}
-impl StyledDisplay for &str {
-    fn render(&self) -> StyledContent<String> {
-        default_styled_content(ToString::to_string(&self))
-    }
-}
-impl StyledDisplay for String {
-    fn render(&self) -> StyledContent<String> {
-        default_styled_content(ToString::to_string(&self))
-    }
-}
-// TODO this currently has incorrect offset
-impl StyledDisplay for StyledBuf {
-    fn render(&self) -> StyledContent<String> {
-        default_styled_content(ToString::to_string(&self))
-    }
-}
-impl StyledDisplay for StyledContent<String> {
-    fn render(&self) -> StyledContent<String> {
-        self.clone()
-    }
-}
-impl StyledDisplay for StyledContent<&str> {
-    fn render(&self) -> StyledContent<String> {
-        default_styled_content(ToString::to_string(self.content()))
-    }
-}
-
-// would technically like to make macro accept ToString but we want special behavior for option
-// type
-
-/// Macro to easily compose [StyledBuf] for use in prompt implementation
-///
-/// Note need crossterm::style::Stylize
-#[macro_export]
-macro_rules! styled {
-    ($($(@($($style:ident),*))? $part:expr),* $(,)*) => {{
-        use $crate::{painter::StyledBuf, prompt::StyledDisplay};
-
-        StyledBuf::from_iter(vec![
-            $({
-                // TODO this will probably return a pretty vague compiler error, if possible try to find
-                // way to panic with decent message when the cast doesn't work
-                let part: &dyn StyledDisplay = &$part;
-                part.render()$($(.$style())*)?
-            }),*
-        ])
-    }};
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn styled_macro() {
-        use crossterm::style::Stylize;
-        println!("test {}", "lol".blue().reset());
-
-        let styled_buf = styled! {
-            @(red,bold) Some("lol"),
-            "lol",
-            String::from("lol"),
-            "lol".blue(),
-            styled! { "lol" }
-        };
-        println!("out {styled_buf}");
     }
 }

--- a/crates/shrs_utils/Cargo.toml
+++ b/crates/shrs_utils/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 crossterm = "0.26"
 derive_builder = "0.12"
 ropey = "1.6"
+unicode-width = "0.1"
 
 anyhow = "1"
 thiserror = "1"

--- a/crates/shrs_utils/src/lib.rs
+++ b/crates/shrs_utils/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod algo;
 pub mod cursor_buffer;
 pub mod macros;
+pub mod styled_buf;

--- a/crates/shrs_utils/src/styled_buf.rs
+++ b/crates/shrs_utils/src/styled_buf.rs
@@ -1,0 +1,207 @@
+use std::{collections::HashMap, fmt::Display};
+
+use crossterm::style::{ContentStyle, StyledContent};
+use unicode_width::UnicodeWidthStr;
+
+/// Text to be rendered by painter
+#[derive(Clone)]
+pub struct StyledBuf {
+    pub content: String,
+    styles: Vec<ContentStyle>,
+}
+
+impl StyledBuf {
+    pub fn empty() -> Self {
+        Self {
+            content: String::new(),
+            styles: vec![],
+        }
+    }
+    pub fn new(content: &str, style: ContentStyle) -> Self {
+        let mut s = Self::empty();
+        s.push(content, style);
+        s
+    }
+
+    pub fn push(&mut self, content: &str, style: ContentStyle) {
+        self.content += content;
+
+        for _ in content.chars() {
+            self.styles.push(style);
+        }
+    }
+
+    pub fn lines(&self) -> Vec<Vec<StyledContent<String>>> {
+        let mut lines: Vec<Vec<StyledContent<String>>> = vec![];
+        let mut i = 0;
+        for line in self.content.split("\n") {
+            let mut x: Vec<StyledContent<String>> = vec![];
+
+            for c in line.chars() {
+                x.push(StyledContent::new(self.styles[i], c.to_string()));
+                i += 1;
+            }
+            i += 1;
+            lines.push(x);
+        }
+        lines
+    }
+    pub fn spans(&self) -> Vec<StyledContent<String>> {
+        let mut x: Vec<StyledContent<String>> = vec![];
+        for (i, c) in self.content.chars().enumerate() {
+            x.push(StyledContent::new(self.styles[i], c.to_string()));
+        }
+        x
+    }
+    //can be simply changed to just the len(lines())-1
+    //kept for now
+    pub fn count_newlines(&self) -> u16 {
+        self.content
+            .chars()
+            .into_iter()
+            .filter(|c| *c == '\n')
+            .count()
+            .try_into()
+            .unwrap()
+    }
+
+    /// Length of content in characters
+    ///
+    /// The length returned is the 'visual' length of the character, in other words, how many
+    /// terminal columns it takes up
+    pub fn content_len(&self) -> u16 {
+        UnicodeWidthStr::width(self.content.as_str()) as u16
+    }
+
+    pub fn change_style(&mut self, c_style: HashMap<usize, ContentStyle>, offset: usize) {
+        for (u, s) in c_style.into_iter() {
+            if offset <= u {
+                self.styles[u - offset] = s;
+            }
+        }
+    }
+}
+pub fn line_content_len(line: Vec<StyledContent<String>>) -> u16 {
+    let c = line
+        .iter()
+        .map(|x| x.content().as_str())
+        .collect::<String>();
+    UnicodeWidthStr::width(c.as_str()) as u16
+}
+
+impl Display for StyledBuf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.content)?;
+        Ok(())
+    }
+}
+
+impl FromIterator<StyledContent<String>> for StyledBuf {
+    fn from_iter<T: IntoIterator<Item = StyledContent<String>>>(iter: T) -> Self {
+        let mut buf = Self::empty();
+        for i in iter {
+            buf.push(i.content(), i.style().to_owned());
+        }
+        buf
+    }
+}
+fn default_styled_content(s: String) -> StyledContent<String> {
+    StyledContent::new(ContentStyle::default(), s)
+}
+
+/// Valid types that can be passed to the styled macro
+// cool since anyone can implement this trait to add something else that can be passed to this
+// macro
+pub trait StyledDisplay {
+    fn render(&self) -> StyledContent<String>;
+}
+impl<T: ToString> StyledDisplay for Option<T> {
+    fn render(&self) -> StyledContent<String> {
+        let styled = self
+            .as_ref()
+            .to_owned()
+            .map(|x| x.to_string())
+            .unwrap_or_default();
+        default_styled_content(styled)
+    }
+}
+impl<T: ToString, E> StyledDisplay for Result<T, E> {
+    fn render(&self) -> StyledContent<String> {
+        let styled = self
+            .as_ref()
+            .to_owned()
+            .map(|x| x.to_string())
+            .unwrap_or_default();
+        default_styled_content(styled)
+    }
+}
+impl StyledDisplay for &str {
+    fn render(&self) -> StyledContent<String> {
+        default_styled_content(ToString::to_string(&self))
+    }
+}
+impl StyledDisplay for String {
+    fn render(&self) -> StyledContent<String> {
+        default_styled_content(ToString::to_string(&self))
+    }
+}
+// TODO this currently has incorrect offset
+impl StyledDisplay for StyledBuf {
+    fn render(&self) -> StyledContent<String> {
+        default_styled_content(ToString::to_string(&self))
+    }
+}
+impl StyledDisplay for StyledContent<String> {
+    fn render(&self) -> StyledContent<String> {
+        self.clone()
+    }
+}
+impl StyledDisplay for StyledContent<&str> {
+    fn render(&self) -> StyledContent<String> {
+        StyledBuf::empty();
+
+        default_styled_content(ToString::to_string(self.content()))
+    }
+}
+
+// would technically like to make macro accept ToString but we want special behavior for option
+// type
+
+/// Macro to easily compose [StyledBuf] for use in prompt implementation
+///
+/// Note need crossterm::style::Stylize
+#[macro_export]
+macro_rules! styled {
+    ($($(@($($style:ident),*))? $part:expr),* $(,)*) => {{
+
+        use $crate::{styled_buf::StyledBuf,styled_buf::StyledDisplay };
+
+        StyledBuf::from_iter(vec![
+            $({
+                // TODO this will probably return a pretty vague compiler error, if possible try to find
+                // way to panic with decent message when the cast doesn't work
+                let part: &dyn StyledDisplay = &$part;
+                part.render()$($(.$style())*)?
+            }),*
+        ])
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn styled_macro() {
+        use crossterm::style::Stylize;
+        println!("test {}", "lol".blue().reset());
+
+        let styled_buf = styled! {
+            @(red,bold) Some("lol"),
+            "lol",
+            String::from("lol"),
+            "lol".blue(),
+            styled! { "lol" }
+        };
+        println!("out {styled_buf}");
+    }
+}

--- a/plugins/shrs_cd_tools/src/lib.rs
+++ b/plugins/shrs_cd_tools/src/lib.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 
 use anymap::AnyMap;
 use query::{Query, QueryResult};
-use shrs::prelude::*;
+use shrs::prelude::{styled_buf::StyledBuf, *};
 
 pub struct DirParsePlugin {
     // pub modules: Option<Vec<Query>>,

--- a/plugins/shrs_command_timer/examples/command_time.rs
+++ b/plugins/shrs_command_timer/examples/command_time.rs
@@ -1,4 +1,4 @@
-use shrs::prelude::*;
+use shrs::prelude::{styled_buf::StyledBuf, *};
 use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
 
 struct MyPrompt;


### PR DESCRIPTION
Moving StyledBuf and macro to utils and adding styledbuf method to output writer. StyledBuf is meant to be the generic way of representing styled text.