### PR TITLE
changing register to hook

### DIFF
--- a/crates/shrs_core/src/hooks.rs
+++ b/crates/shrs_core/src/hooks.rs
@@ -146,11 +146,11 @@ impl Default for Hooks {
     fn default() -> Self {
         let mut hooks = Hooks::new();
 
-        hooks.register(startup_hook);
-        hooks.register(before_command_hook);
-        hooks.register(after_command_hook);
-        hooks.register(change_dir_hook);
-        hooks.register(job_exit_hook);
+        hooks.insert(startup_hook);
+        hooks.insert(before_command_hook);
+        hooks.insert(after_command_hook);
+        hooks.insert(change_dir_hook);
+        hooks.insert(job_exit_hook);
 
         hooks
     }
@@ -164,7 +164,7 @@ impl Hooks {
     }
 
     /// Registers a new hook
-    pub fn register<C: Clone + 'static>(&mut self, hook: HookFn<C>) {
+    pub fn insert<C: Clone + 'static>(&mut self, hook: HookFn<C>) {
         match self.hooks.get_mut::<Vec<HookFn<C>>>() {
             Some(hook_list) => {
                 hook_list.push(hook);

--- a/plugins/shrs_analytics/src/lib.rs
+++ b/plugins/shrs_analytics/src/lib.rs
@@ -43,8 +43,8 @@ impl AnalyticsPlugin {
 impl Plugin for AnalyticsPlugin {
     fn init(&self, shell: &mut ShellConfig) -> Result<()> {
         shell.builtins.insert("analytics", AnalyticsBuiltin);
-        shell.hooks.register(record_dir_change);
-        shell.hooks.register(most_common_commands);
+        shell.hooks.insert(record_dir_change);
+        shell.hooks.insert(most_common_commands);
         shell.state.insert(AnalyticsState::new());
 
         Ok(())

--- a/plugins/shrs_autocd/src/lib.rs
+++ b/plugins/shrs_autocd/src/lib.rs
@@ -36,7 +36,7 @@ pub fn after_command_hook(
 
 impl Plugin for AutocdPlugin {
     fn init(&self, shell: &mut ShellConfig) -> anyhow::Result<()> {
-        shell.hooks.register(after_command_hook);
+        shell.hooks.insert(after_command_hook);
 
         Ok(())
     }

--- a/plugins/shrs_cd_stack/src/lib.rs
+++ b/plugins/shrs_cd_stack/src/lib.rs
@@ -67,7 +67,7 @@ impl Plugin for CdStackPlugin {
         // constructed yet
         cd_stack_state.push(&current_dir().unwrap());
         shell.state.insert(cd_stack_state);
-        shell.hooks.register(change_dir_hook);
+        shell.hooks.insert(change_dir_hook);
 
         Ok(())
     }

--- a/plugins/shrs_cd_tools/src/lib.rs
+++ b/plugins/shrs_cd_tools/src/lib.rs
@@ -104,8 +104,8 @@ impl Plugin for DirParsePlugin {
         ]);
 
         shell.state.insert(DirParseState::new(modules));
-        shell.hooks.register(startup_hook);
-        shell.hooks.register(change_dir_hook);
+        shell.hooks.insert(startup_hook);
+        shell.hooks.insert(change_dir_hook);
 
         Ok(())
     }

--- a/plugins/shrs_command_timer/src/lib.rs
+++ b/plugins/shrs_command_timer/src/lib.rs
@@ -46,8 +46,8 @@ pub struct CommandTimerPlugin;
 
 impl Plugin for CommandTimerPlugin {
     fn init(&self, shell: &mut shrs::ShellConfig) -> anyhow::Result<()> {
-        shell.hooks.register(before_command_hook);
-        shell.hooks.register(after_command_hook);
+        shell.hooks.insert(before_command_hook);
+        shell.hooks.insert(after_command_hook);
         shell.state.insert(CommandTimerState::new());
 
         Ok(())

--- a/plugins/shrs_mux/src/lib.rs
+++ b/plugins/shrs_mux/src/lib.rs
@@ -93,7 +93,7 @@ impl Plugin for MuxPlugin {
         shell.state.insert(MuxState::new(lang_names).unwrap());
         let langs_map = HashMap::from_iter(langs);
         shell.lang = Box::new(MuxLang::new(langs_map));
-        shell.hooks.register(swap_lang_options);
+        shell.hooks.insert(swap_lang_options);
 
         Ok(())
     }

--- a/plugins/shrs_output_capture/src/lib.rs
+++ b/plugins/shrs_output_capture/src/lib.rs
@@ -26,7 +26,7 @@ pub struct OutputCapturePlugin;
 
 impl Plugin for OutputCapturePlugin {
     fn init(&self, shell: &mut shrs::ShellConfig) -> anyhow::Result<()> {
-        shell.hooks.register(after_command_hook);
+        shell.hooks.insert(after_command_hook);
         shell.builtins.insert("again", AgainBuiltin::new());
         shell.state.insert(OutputCaptureState::new());
 

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -171,7 +171,7 @@ a rusty POSIX shell | build {}"#,
         Ok(())
     };
     let mut hooks = Hooks::new();
-    hooks.register(startup_msg);
+    hooks.insert(startup_msg);
 
     // =-=-= Shell =-=-=
     // Construct the final shell


### PR DESCRIPTION
when creating a plugin insert is the name of the method when adding builtins and state. It's unintuitive that register is used for hooks