### PR TITLE
Fix Clippy lints

### DIFF
--- a/crates/shrs/examples/conditional_alias.rs
+++ b/crates/shrs/examples/conditional_alias.rs
@@ -11,7 +11,7 @@ fn in_home_directory() -> bool {
 }
 
 fn main() {
-    let mut alias = Alias::new();
+    let mut alias = Alias::default();
     alias.set(
         "inhome",
         AliasInfo::with_rule("true", |_ctx| in_home_directory()),

--- a/crates/shrs/examples/config_file.rs
+++ b/crates/shrs/examples/config_file.rs
@@ -18,7 +18,7 @@ fn main() {
     let myconfig: Config = ron::from_str(&config_file).unwrap();
 
     let alias = Alias::from_iter(myconfig.aliases);
-    let mut env = Env::new();
+    let mut env = Env::default();
     env.load();
     for (ref k, ref v) in myconfig.envs {
         env.set(k, v);

--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -1,12 +1,6 @@
 //! Shell configuration options
 
-use std::{
-    cell::RefCell,
-    io::{stdout, BufRead, BufWriter, Write},
-    process::ExitStatus,
-    rc::Rc,
-    time::Instant,
-};
+use std::{cell::RefCell, process::ExitStatus, time::Instant};
 
 use log::{info, warn};
 use shrs_core::prelude::*;
@@ -38,11 +32,11 @@ pub struct ShellConfig {
     pub readline: Box<dyn Readline>,
 
     /// Aliases, see [Alias]
-    #[builder(default = "Alias::new()")]
+    #[builder(default = "Alias::default()")]
     pub alias: Alias,
 
     /// Environment variables, see [Env]
-    #[builder(default = "Env::new()")]
+    #[builder(default = "Env::default()")]
     pub env: Env,
 
     // /// List of defined functions
@@ -53,7 +47,7 @@ pub struct ShellConfig {
     pub theme: Theme,
 
     /// Command language
-    #[builder(default = "Box::new(PosixLang::new())")]
+    #[builder(default = "Box::new(PosixLang::default())")]
     #[builder(setter(custom))]
     pub lang: Box<dyn Lang>,
 
@@ -63,31 +57,31 @@ pub struct ShellConfig {
     pub plugins: Vec<Box<dyn Plugin>>, // TODO could also maybe use anymap to get the concrete type
 
     /// Globally accessible state, see [State]
-    #[builder(default = "State::new()")]
+    #[builder(default = "State::default()")]
     #[builder(setter(custom))]
     pub state: State,
 
     /// History, see [History]
-    #[builder(default = "Box::new(DefaultHistory::new())")]
+    #[builder(default = "Box::new(DefaultHistory::default())")]
     #[builder(setter(custom))]
     pub history: Box<dyn History<HistoryItem = String>>,
 
     /// Keybindings, see [Keybinding]
-    #[builder(default = "Box::new(DefaultKeybinding::new())")]
+    #[builder(default = "Box::new(DefaultKeybinding::default())")]
     #[builder(setter(custom))]
     pub keybinding: Box<dyn Keybinding>,
 }
 
 impl ShellBuilder {
     pub fn with_plugin<P: std::any::Any + Plugin>(mut self, plugin: P) -> Self {
-        let mut cur_plugins = self.plugins.unwrap_or(vec![]);
+        let mut cur_plugins = self.plugins.unwrap_or_default();
         cur_plugins.push(Box::new(plugin));
         self.plugins = Some(cur_plugins);
 
         self
     }
     pub fn with_state<T: 'static>(mut self, state: T) -> Self {
-        let mut cur_state = self.state.unwrap_or(State::new());
+        let mut cur_state = self.state.unwrap_or_default();
         cur_state.insert(state);
         self.state = Some(cur_state);
         self
@@ -145,7 +139,7 @@ impl ShellConfig {
             alias: self.alias,
             out: OutputWriter::default(),
             state: self.state,
-            jobs: Jobs::new(),
+            jobs: Jobs::default(),
             startup_time: Instant::now(),
             history: self.history,
         };
@@ -237,7 +231,7 @@ fn run_shell(
         let builtin_cmd = sh
             .builtins
             .iter()
-            .find(|(builtin_name, _)| *builtin_name == &cmd_name)
+            .find(|(builtin_name, _)| *builtin_name == cmd_name)
             .map(|(_, builtin_cmd)| builtin_cmd);
 
         let mut cmd_output: CmdOutput = CmdOutput::error();

--- a/crates/shrs_core/src/alias.rs
+++ b/crates/shrs_core/src/alias.rs
@@ -38,7 +38,7 @@ impl AliasInfo {
     pub fn always<S: ToString>(subst: S) -> Self {
         Self {
             subst: subst.to_string(),
-            rule: AliasRule(Box::new(|ctx| -> bool { true })),
+            rule: AliasRule(Box::new(|_| -> bool { true })),
         }
     }
 
@@ -59,18 +59,12 @@ impl AliasInfo {
 ///
 /// Aliases are stored as the raw string entered, therefore invalid syntax can be set as an alias,
 /// but upon substitution the error is emitted. This may be changed in the future.
+#[derive(Default)]
 pub struct Alias {
     aliases: MultiMap<String, AliasInfo>,
 }
 
 impl Alias {
-    /// Construct a new instance of [Alias]
-    pub fn new() -> Self {
-        Alias {
-            aliases: MultiMap::new(),
-        }
-    }
-
     /// Fetch all possible aliases
     pub fn get(&self, alias_ctx: &AliasRuleCtx) -> Vec<&String> {
         let alias_list = match self.aliases.get_vec(alias_ctx.alias_name) {
@@ -80,7 +74,7 @@ impl Alias {
 
         alias_list
             .iter()
-            .filter(|alias_info| (alias_info.rule.0)(&alias_ctx))
+            .filter(|alias_info| (alias_info.rule.0)(alias_ctx))
             .map(|alias_info| &alias_info.subst)
             .collect::<Vec<_>>()
     }

--- a/crates/shrs_core/src/builtin/alias.rs
+++ b/crates/shrs_core/src/builtin/alias.rs
@@ -1,5 +1,3 @@
-use std::io::{stdout, Write};
-
 use clap::{Parser, Subcommand};
 
 use super::BuiltinCmd;
@@ -23,14 +21,14 @@ pub struct AliasBuiltin {}
 impl BuiltinCmd for AliasBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _rt: &mut Runtime,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 
-        let mut it = cli.alias.splitn(2, "=");
+        let mut it = cli.alias.splitn(2, '=');
         let alias_name = it.next().unwrap();
         match it.next() {
             Some(alias_def) => {

--- a/crates/shrs_core/src/builtin/cd.rs
+++ b/crates/shrs_core/src/builtin/cd.rs
@@ -1,13 +1,9 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
 use super::BuiltinCmd;
 use crate::{
-    hooks::ChangeDirCtx,
     prelude::CmdOutput,
     shell::{set_working_dir, Context, Runtime, Shell},
 };
@@ -26,7 +22,7 @@ impl BuiltinCmd for CdBuiltin {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 

--- a/crates/shrs_core/src/builtin/debug.rs
+++ b/crates/shrs_core/src/builtin/debug.rs
@@ -1,7 +1,5 @@
 //! Builtin command that has access to shell env for debug and prototyping
 
-use std::io::{stdout, Write};
-
 use clap::{Parser, Subcommand};
 
 use super::BuiltinCmd;
@@ -27,10 +25,10 @@ pub struct DebugBuiltin {}
 impl BuiltinCmd for DebugBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 

--- a/crates/shrs_core/src/builtin/exit.rs
+++ b/crates/shrs_core/src/builtin/exit.rs
@@ -10,10 +10,10 @@ pub struct ExitBuiltin {}
 impl BuiltinCmd for ExitBuiltin {
     fn run(
         &self,
-        sh: &Shell,
-        ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _sh: &Shell,
+        _ctx: &mut Context,
+        _rt: &mut Runtime,
+        _args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         std::process::exit(0)
     }

--- a/crates/shrs_core/src/builtin/export.rs
+++ b/crates/shrs_core/src/builtin/export.rs
@@ -1,5 +1,3 @@
-use std::io::{stdout, Write};
-
 use clap::{Parser, Subcommand};
 
 use super::BuiltinCmd;
@@ -26,10 +24,10 @@ pub struct ExportBuiltin {}
 impl BuiltinCmd for ExportBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 
@@ -51,7 +49,7 @@ impl BuiltinCmd for ExportBuiltin {
         }
 
         for var in cli.vars {
-            let mut it = var.splitn(2, "=");
+            let mut it = var.splitn(2, '=');
             let var = it.next().unwrap();
             let val = it.next().unwrap_or_default();
 

--- a/crates/shrs_core/src/builtin/help.rs
+++ b/crates/shrs_core/src/builtin/help.rs
@@ -1,13 +1,7 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
-
 use clap::{Parser, Subcommand};
 
-use super::{BuiltinCmd, Builtins};
+use super::BuiltinCmd;
 use crate::{
-    hooks::ChangeDirCtx,
     prelude::CmdOutput,
     shell::{Context, Runtime, Shell},
 };
@@ -31,8 +25,8 @@ impl BuiltinCmd for HelpBuiltin {
         &self,
         sh: &Shell,
         ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _rt: &mut Runtime,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 

--- a/crates/shrs_core/src/builtin/history.rs
+++ b/crates/shrs_core/src/builtin/history.rs
@@ -2,8 +2,6 @@
 
 // debatable if crate::history should be moved to crate::builtin::history
 
-use std::io::{stdout, Write};
-
 use clap::{Parser, Subcommand};
 
 use super::BuiltinCmd;
@@ -31,10 +29,10 @@ pub struct HistoryBuiltin {}
 impl BuiltinCmd for HistoryBuiltin {
     fn run(
         &self,
-        sh: &Shell,
-        ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _sh: &Shell,
+        _ctx: &mut Context,
+        _rt: &mut Runtime,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         // TODO hack
         let cli = Cli::try_parse_from(args)?;
@@ -50,10 +48,10 @@ impl BuiltinCmd for HistoryBuiltin {
             Some(Commands::Clear) => {
                 // ctx.history.clear();
             },
-            Some(Commands::Run { index }) => {
+            Some(Commands::Run { .. }) => {
                 todo!()
             },
-            Some(Commands::Search { query }) => {
+            Some(Commands::Search { .. }) => {
                 todo!()
             },
         }

--- a/crates/shrs_core/src/builtin/jobs.rs
+++ b/crates/shrs_core/src/builtin/jobs.rs
@@ -1,11 +1,5 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
-
 use super::BuiltinCmd;
 use crate::{
-    hooks::ChangeDirCtx,
     prelude::CmdOutput,
     shell::{Context, Runtime, Shell},
 };
@@ -16,13 +10,14 @@ pub struct JobsBuiltin {}
 impl BuiltinCmd for JobsBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _rt: &mut Runtime,
+        _args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         for (job_id, _) in ctx.jobs.iter() {
-            ctx.out.println(job_id.to_string().as_str());
+            // TODO: This should probably have error handling
+            let _ = ctx.out.println(job_id.to_string().as_str());
         }
 
         Ok(CmdOutput::success())

--- a/crates/shrs_core/src/builtin/mod.rs
+++ b/crates/shrs_core/src/builtin/mod.rs
@@ -28,18 +28,6 @@ use crate::{
     shell::{Context, Runtime, Shell},
 };
 
-macro_rules! hashmap (
-    { $($key:expr => $value:expr),+ } => {
-	{
-	    let mut m = std::collections::HashMap::new();
-	    $(
-		m.insert($key, $value);
-	    )+
-	    m
-	}
-    };
-);
-
 // TODO could prob just be a map, to support arbitrary (user defined even) number of builtin commands
 // just provide an easy way to override the default ones
 /// Store for all registered builtin commands
@@ -68,6 +56,8 @@ impl Builtins {
     }
 
     /// Find a builtin by name
+    // Clippy thinks this shouldn't be a box, but it does not compile if you follow the warning
+    #[allow(clippy::borrowed_box)]
     pub fn get(&self, name: &'static str) -> Option<&Box<dyn BuiltinCmd>> {
         self.builtins.get(name)
     }
@@ -79,41 +69,32 @@ impl Default for Builtins {
             builtins: HashMap::from([
                 (
                     "history",
-                    Box::new(HistoryBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<HistoryBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
-                (
-                    "exit",
-                    Box::new(ExitBuiltin::default()) as Box<dyn BuiltinCmd>,
-                ),
-                ("cd", Box::new(CdBuiltin::default()) as Box<dyn BuiltinCmd>),
+                ("exit", Box::<ExitBuiltin>::default() as Box<dyn BuiltinCmd>),
+                ("cd", Box::<CdBuiltin>::default() as Box<dyn BuiltinCmd>),
                 (
                     "debug",
-                    Box::new(DebugBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<DebugBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
                 (
                     "export",
-                    Box::new(ExportBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<ExportBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
                 (
                     "alias",
-                    Box::new(AliasBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<AliasBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
                 (
                     "unalias",
-                    Box::new(UnaliasBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<UnaliasBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
                 (
                     "source",
-                    Box::new(SourceBuiltin::default()) as Box<dyn BuiltinCmd>,
+                    Box::<SourceBuiltin>::default() as Box<dyn BuiltinCmd>,
                 ),
-                (
-                    "jobs",
-                    Box::new(JobsBuiltin::default()) as Box<dyn BuiltinCmd>,
-                ),
-                (
-                    "help",
-                    Box::new(HelpBuiltin::default()) as Box<dyn BuiltinCmd>,
-                ),
+                ("jobs", Box::<JobsBuiltin>::default() as Box<dyn BuiltinCmd>),
+                ("help", Box::<HelpBuiltin>::default() as Box<dyn BuiltinCmd>),
             ]),
         }
     }
@@ -126,6 +107,6 @@ pub trait BuiltinCmd {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput>;
 }

--- a/crates/shrs_core/src/builtin/source.rs
+++ b/crates/shrs_core/src/builtin/source.rs
@@ -1,9 +1,4 @@
-use std::{
-    env,
-    fs::read_to_string,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{fs::read_to_string, path::PathBuf, process::Command};
 
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -30,10 +25,10 @@ pub struct SourceBuiltin {}
 impl BuiltinCmd for SourceBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _rt: &mut Runtime,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 
@@ -52,7 +47,7 @@ impl BuiltinCmd for SourceBuiltin {
             Some(interp) => {
                 let s = format!("using interp {} at {}", interp.as_str(), &cli.source_file);
                 ctx.out.println(s)?;
-                let mut child = Command::new(interp.as_str())
+                let mut _child = Command::new(interp.as_str())
                     .args(vec![cli.source_file])
                     .spawn()?;
 

--- a/crates/shrs_core/src/builtin/unalias.rs
+++ b/crates/shrs_core/src/builtin/unalias.rs
@@ -1,5 +1,3 @@
-use std::io::{stdout, Write};
-
 use clap::{Parser, Subcommand};
 
 use super::BuiltinCmd;
@@ -24,10 +22,10 @@ pub struct UnaliasBuiltin {}
 impl BuiltinCmd for UnaliasBuiltin {
     fn run(
         &self,
-        sh: &Shell,
+        _sh: &Shell,
         ctx: &mut Context,
-        rt: &mut Runtime,
-        args: &Vec<String>,
+        _rt: &mut Runtime,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 

--- a/crates/shrs_core/src/cmd_output.rs
+++ b/crates/shrs_core/src/cmd_output.rs
@@ -1,12 +1,4 @@
-use std::{
-    default,
-    io::{self, stdout, BufWriter, Write},
-    os::unix::process::ExitStatusExt,
-    process::{self, ExitStatus, Output},
-};
-
-use crossterm::{style::Print, QueueableCommand};
-use pino_deref::Deref;
+use std::{os::unix::process::ExitStatusExt, process::ExitStatus};
 
 #[derive(Clone, Debug)]
 pub struct CmdOutput {

--- a/crates/shrs_core/src/env.rs
+++ b/crates/shrs_core/src/env.rs
@@ -1,8 +1,7 @@
 //! Environment variables
 
-use std::{collections::HashMap, env, ffi::OsString};
+use std::{collections::HashMap, env};
 
-use shrs_utils::warn_if_err;
 use thiserror::Error;
 
 /// Hook for when environment variable gets modified
@@ -32,19 +31,12 @@ pub enum EnvError {
 
 /// Set and query environment variables
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Env {
     var_table: HashMap<String, String>,
 }
 
 impl Env {
-    /// Construct a new [Env] struct
-    pub fn new() -> Self {
-        Env {
-            var_table: HashMap::new(),
-        }
-    }
-
     /// Load environment variables into shrs
     ///
     /// Useful if calling shrs from another shell and some environment variables are already set

--- a/crates/shrs_core/src/history.rs
+++ b/crates/shrs_core/src/history.rs
@@ -24,17 +24,17 @@ pub trait History {
     fn len(&self) -> usize;
     /// Get a history entry by index
     fn get(&self, i: usize) -> Option<&Self::HistoryItem>;
+
+    /// Check if the history is empty
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Default implementation of [History] that saves history in process memory
+#[derive(Default)]
 pub struct DefaultHistory {
     hist: Vec<String>,
-}
-
-impl DefaultHistory {
-    pub fn new() -> Self {
-        DefaultHistory { hist: vec![] }
-    }
 }
 
 impl History for DefaultHistory {
@@ -161,9 +161,6 @@ fn parse_history_file(hist_file: PathBuf) -> Result<Vec<String>, FileBackedHisto
         .map_err(FileBackedHistoryError::OpeningHistFile)?;
     let reader = BufReader::new(handle);
     // TODO should error/terminate when a line cannot be read?
-    let hist = reader
-        .lines()
-        .filter_map(|line| line.ok())
-        .collect::<Vec<_>>();
+    let hist = reader.lines().map_while(Result::ok).collect::<Vec<_>>();
     Ok(hist)
 }

--- a/crates/shrs_core/src/hooks.rs
+++ b/crates/shrs_core/src/hooks.rs
@@ -10,24 +10,14 @@
 // - env hook (when environment variable is set/changed)
 // - exit hook (tricky, make sure we know what cases to call this)
 
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-    io::BufWriter,
-    marker::PhantomData,
-    path::PathBuf,
-    process::ExitStatus,
-    time::Duration,
-};
-
-use crossterm::{style::Print, QueueableCommand};
+use std::{path::PathBuf, process::ExitStatus, time::Duration};
 
 use crate::{
     cmd_output::CmdOutput,
     shell::{Context, Runtime, Shell},
 };
 
-pub type HookFn<C: Clone> =
+pub type HookFn<C> =
     fn(sh: &Shell, sh_ctx: &mut Context, sh_rt: &mut Runtime, ctx: &C) -> anyhow::Result<()>;
 
 // TODO this is some pretty sus implementation
@@ -44,9 +34,9 @@ pub struct StartupCtx {
 
 /// Default implementation for [StartupCtx]
 pub fn startup_hook(
-    sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
+    _sh: &Shell,
+    _sh_ctx: &mut Context,
+    _sh_rt: &mut Runtime,
     _ctx: &StartupCtx,
 ) -> anyhow::Result<()> {
     println!("welcome to shrs!");
@@ -66,10 +56,10 @@ pub struct BeforeCommandCtx {
 
 /// Default implementation for [BeforeCommandCtx]
 pub fn before_command_hook(
-    sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
-    ctx: &BeforeCommandCtx,
+    _sh: &Shell,
+    _sh_ctx: &mut Context,
+    _sh_rt: &mut Runtime,
+    _ctx: &BeforeCommandCtx,
 ) -> anyhow::Result<()> {
     // let expanded_cmd = format!("[evaluating] {}\n", ctx.command);
     // out.queue(Print(expanded_cmd))?;
@@ -87,10 +77,10 @@ pub struct AfterCommandCtx {
 
 /// Default implementation for [AfterCommandCtx]
 pub fn after_command_hook(
-    sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
-    ctx: &AfterCommandCtx,
+    _sh: &Shell,
+    _sh_ctx: &mut Context,
+    _sh_rt: &mut Runtime,
+    _ctx: &AfterCommandCtx,
 ) -> anyhow::Result<()> {
     // let exit_code_str = format!("[exit +{}]\n", ctx.exit_code);
     // out.queue(Print(exit_code_str))?;
@@ -106,10 +96,10 @@ pub struct ChangeDirCtx {
 
 /// Default implementation for [ChangeDirCtx]
 pub fn change_dir_hook(
-    sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
-    ctx: &ChangeDirCtx,
+    _sh: &Shell,
+    _sh_ctx: &mut Context,
+    _sh_rt: &mut Runtime,
+    _ctx: &ChangeDirCtx,
 ) -> anyhow::Result<()> {
     Ok(())
 }
@@ -122,9 +112,9 @@ pub struct JobExitCtx {
 
 /// Default implementation for [JobExitCtx]
 pub fn job_exit_hook(
-    sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
+    _sh: &Shell,
+    _sh_ctx: &mut Context,
+    _sh_rt: &mut Runtime,
     ctx: &JobExitCtx,
 ) -> anyhow::Result<()> {
     println!("[exit +{:?}]", ctx.status.code());

--- a/crates/shrs_core/src/jobs.rs
+++ b/crates/shrs_core/src/jobs.rs
@@ -14,11 +14,20 @@ pub struct JobInfo {
 }
 
 /// Keeps track of all the current running jobs
-#[derive(Default)]
 pub struct Jobs {
     foreground: Option<Child>,
     next_id: JobId,
     jobs: HashMap<JobId, JobInfo>,
+}
+
+impl Default for Jobs {
+    fn default() -> Self {
+        Jobs {
+            next_id: 0,
+            jobs: HashMap::new(),
+            foreground: None,
+        }
+    }
 }
 
 impl Jobs {

--- a/crates/shrs_core/src/jobs.rs
+++ b/crates/shrs_core/src/jobs.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use anyhow::anyhow;
-use pino_deref::Deref;
 
 pub type JobId = u32;
 
@@ -15,6 +14,7 @@ pub struct JobInfo {
 }
 
 /// Keeps track of all the current running jobs
+#[derive(Default)]
 pub struct Jobs {
     foreground: Option<Child>,
     next_id: JobId,
@@ -22,14 +22,6 @@ pub struct Jobs {
 }
 
 impl Jobs {
-    pub fn new() -> Self {
-        Jobs {
-            next_id: 0,
-            jobs: HashMap::new(),
-            foreground: None,
-        }
-    }
-
     /// Add new job to be tracked
     pub fn push(&mut self, child: Child, cmd: String) {
         let next_id = self.get_next_id();
@@ -45,14 +37,14 @@ impl Jobs {
     where
         F: FnMut(ExitStatus),
     {
-        self.jobs.retain(|k, v| {
+        self.jobs.retain(|_, v| {
             match v.child.try_wait() {
                 Ok(Some(status)) => {
                     exit_handler(status);
                     false
                 },
                 Ok(None) => true,
-                Err(e) => {
+                Err(_) => {
                     // TODO should throw error that there was issue waiting for job to finish
                     false
                 },

--- a/crates/shrs_core/src/keybinding.rs
+++ b/crates/shrs_core/src/keybinding.rs
@@ -108,17 +108,10 @@ fn parse_modifier(s: &str) -> Result<KeyModifiers, BindingFromStrError> {
 }
 
 /// Default implementation of [Keybinding]
+#[derive(Default)]
 pub struct DefaultKeybinding {
     // TODO this can't take closure right now
     pub bindings: HashMap<Binding, Box<BindingFn>>,
-}
-
-impl DefaultKeybinding {
-    pub fn new() -> Self {
-        Self {
-            bindings: HashMap::new(),
-        }
-    }
 }
 
 impl Keybinding for DefaultKeybinding {
@@ -150,8 +143,6 @@ impl FromIterator<(Binding, Box<BindingFn>)> for DefaultKeybinding {
 
 #[cfg(test)]
 mod tests {
-    use std::process::Command;
-
     use crossterm::event::{KeyCode, KeyModifiers};
 
     use super::parse_keybinding;

--- a/crates/shrs_core/src/keybinding.rs
+++ b/crates/shrs_core/src/keybinding.rs
@@ -127,7 +127,6 @@ impl DefaultKeybinding {
     }
 }
 
-
 impl Keybinding for DefaultKeybinding {
     fn handle_key_event(
         &self,

--- a/crates/shrs_core/src/lib.rs
+++ b/crates/shrs_core/src/lib.rs
@@ -1,9 +1,5 @@
 //! Core functionality of shrs
-
-#[macro_use]
 extern crate derive_builder;
-
-#[macro_use]
 extern crate lazy_static;
 
 pub mod alias;

--- a/crates/shrs_core/src/prompt.rs
+++ b/crates/shrs_core/src/prompt.rs
@@ -1,8 +1,6 @@
 //! Collection of utility functions for building a prompt
 
-use std::{borrow::Cow, ffi::OsString, path::PathBuf, process::Command};
-
-use anyhow::anyhow;
+use std::{path::PathBuf, process::Command};
 
 /// Get the full working directory
 pub fn full_pwd() -> String {
@@ -40,7 +38,7 @@ pub fn top_pwd() -> String {
 pub fn username() -> anyhow::Result<String> {
     let username = Command::new("whoami").output()?.stdout;
     let encoded = std::str::from_utf8(&username)?
-        .strip_suffix("\n")
+        .strip_suffix('\n')
         .unwrap()
         .to_string();
     Ok(encoded)
@@ -50,7 +48,7 @@ pub fn username() -> anyhow::Result<String> {
 pub fn hostname() -> anyhow::Result<String> {
     let username = Command::new("hostname").output()?.stdout;
     let encoded = std::str::from_utf8(&username)?
-        .strip_suffix("\n")
+        .strip_suffix('\n')
         .unwrap()
         .to_string();
     Ok(encoded)

--- a/crates/shrs_core/src/shell.rs
+++ b/crates/shrs_core/src/shell.rs
@@ -2,30 +2,21 @@
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
     env,
-    fs::File,
-    io::{stdin, stdout, BufRead, BufReader, BufWriter, Write},
-    os::unix::process::CommandExt,
     path::{Path, PathBuf},
-    process::{Child, Output, Stdio},
-    rc::Rc,
     time::Instant,
 };
 
 use anyhow::anyhow;
-use crossterm::{style::Print, QueueableCommand};
-use lazy_static::lazy_static;
 use log::error;
 use shrs_job::JobManager;
-use thiserror::Error;
 
 use crate::{
     alias::Alias,
     builtin::Builtins,
     env::Env,
     history::History,
-    hooks::{AfterCommandCtx, BeforeCommandCtx, ChangeDirCtx, Hooks, JobExitCtx, StartupCtx},
+    hooks::{ChangeDirCtx, Hooks},
     jobs::Jobs,
     keybinding::Keybinding,
     lang::Lang,

--- a/crates/shrs_core/src/state.rs
+++ b/crates/shrs_core/src/state.rs
@@ -1,18 +1,12 @@
 //! Globally accessible state store
 
 /// State store that uses types to index
+#[derive(Default)]
 pub struct State {
     store: anymap::Map,
 }
 
 impl State {
-    /// Initialize the state store
-    pub fn new() -> State {
-        State {
-            store: anymap::Map::new(),
-        }
-    }
-
     pub fn insert<T: 'static>(&mut self, data: T) {
         self.store.insert::<T>(data);
     }

--- a/crates/shrs_job/src/job.rs
+++ b/crates/shrs_job/src/job.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use crate::log_if_err;
 
+#[allow(non_camel_case_types)]
 pub type pid_t = i32;
 
 #[derive(Error, Debug)]

--- a/crates/shrs_job/src/process.rs
+++ b/crates/shrs_job/src/process.rs
@@ -63,27 +63,27 @@ struct BuiltinProcess {
     stdout: Option<Stdin>,
 }
 
-impl BuiltinProcess {
-    pub fn new<S1, S2>(
-        program: S1,
-        args: &[S2],
-        status_code: ExitStatus,
-        stdout: Option<Stdin>,
-    ) -> Self
-    where
-        S1: AsRef<str>,
-        S2: AsRef<str>,
-    {
-        Self {
-            argv: iter::once(program)
-                .map(|p| p.as_ref().to_string())
-                .chain(args.iter().map(|arg| arg.as_ref().to_string()))
-                .collect(),
-            status_code,
-            stdout,
-        }
-    }
-}
+// impl BuiltinProcess {
+//     pub fn new<S1, S2>(
+//         program: S1,
+//         args: &[S2],
+//         status_code: ExitStatus,
+//         stdout: Option<Stdin>,
+//     ) -> Self
+//     where
+//         S1: AsRef<str>,
+//         S2: AsRef<str>,
+//     {
+//         Self {
+//             argv: iter::once(program)
+//                 .map(|p| p.as_ref().to_string())
+//                 .chain(args.iter().map(|arg| arg.as_ref().to_string()))
+//                 .collect(),
+//             status_code,
+//             stdout,
+//         }
+//     }
+// }
 
 impl Process for BuiltinProcess {
     fn id(&self) -> Option<ProcessId> {

--- a/crates/shrs_lang/src/eval.rs
+++ b/crates/shrs_lang/src/eval.rs
@@ -22,7 +22,7 @@ pub fn run_external_command(
     ctx: &mut Context,
     rt: &mut Runtime,
     cmd: &str,
-    args: &Vec<String>,
+    args: &[String],
     stdin: Stdio,
     stdout: Stdio,
     pgid: Option<i32>,

--- a/crates/shrs_lang/src/eval2.rs
+++ b/crates/shrs_lang/src/eval2.rs
@@ -7,9 +7,9 @@ use shrs_job::{run_external_command, JobManager, Output, Process, ProcessGroup, 
 use crate::ast;
 
 pub struct Os {
-    job_manager: JobManager,
+    _job_manager: JobManager,
     /// Exit status of last command executed.
-    last_exit_status: ExitStatus,
+    _last_exit_status: ExitStatus,
 }
 
 pub fn run_job(

--- a/crates/shrs_lang/src/parser.rs
+++ b/crates/shrs_lang/src/parser.rs
@@ -11,13 +11,10 @@ pub enum Error {
     UnsuccessfulParse,
 }
 
+#[derive(Default)]
 pub struct Parser {}
 
 impl Parser {
-    pub fn new() -> Self {
-        Parser {}
-    }
-
     pub fn parse(&self, lexer: Lexer) -> Result<ast::Command, Error> {
         grammar::ProgramParser::new()
             .parse(lexer.input(), lexer)

--- a/crates/shrs_lang/src/process.rs
+++ b/crates/shrs_lang/src/process.rs
@@ -78,7 +78,7 @@ pub enum Pgid {
 
 // Run a command
 pub fn run_process(
-    argv: &Vec<String>,
+    argv: &[String],
     pgid: Pgid,
     ctx: &Context,
 ) -> Result<ExitStatus, std::io::Error> {
@@ -94,7 +94,7 @@ pub fn run_process(
 }
 
 // Code to run in child after new process is forked
-fn setup_process(argv: &Vec<String>, pgid: Pgid, ctx: &Context) -> Result<(), std::io::Error> {
+fn setup_process(argv: &[String], pgid: Pgid, ctx: &Context) -> Result<(), std::io::Error> {
     // If interactive need to give the current process control of the tty
     let shell_term = STDIN_FILENO;
     if ctx.is_interactive {

--- a/crates/shrs_line/src/buffer_history.rs
+++ b/crates/shrs_line/src/buffer_history.rs
@@ -12,20 +12,16 @@ pub trait BufferHistory {
 }
 
 // Stores Buffer data and cursor index
+#[derive(Default)]
 struct HistItem(String, usize);
 
+#[derive(Default)]
 pub struct DefaultBufferHistory {
     index: usize,
     hist: Vec<HistItem>,
 }
 
 impl DefaultBufferHistory {
-    pub fn new() -> Self {
-        DefaultBufferHistory {
-            hist: vec![HistItem(String::new(), 0)],
-            index: 0,
-        }
-    }
     fn update_buffer(&mut self, cb: &mut CursorBuffer) -> cursor_buffer::Result<()> {
         let new_buf = &self.hist.get(self.index).unwrap().0;
         cb.clear();

--- a/crates/shrs_line/src/buffer_history.rs
+++ b/crates/shrs_line/src/buffer_history.rs
@@ -15,10 +15,18 @@ pub trait BufferHistory {
 #[derive(Default)]
 struct HistItem(String, usize);
 
-#[derive(Default)]
 pub struct DefaultBufferHistory {
     index: usize,
     hist: Vec<HistItem>,
+}
+
+impl Default for DefaultBufferHistory {
+    fn default() -> Self {
+        DefaultBufferHistory {
+            hist: vec![HistItem(String::new(), 0)],
+            index: 0,
+        }
+    }
 }
 
 impl DefaultBufferHistory {

--- a/crates/shrs_line/src/completion/completer.rs
+++ b/crates/shrs_line/src/completion/completer.rs
@@ -154,7 +154,7 @@ pub fn filename_action(ctx: &CompletionCtx) -> Vec<Completion> {
     let drop_end = drop_path_end(cur_word);
     let cur_path = to_absolute(&drop_end, &dirs::home_dir().unwrap());
 
-    let output = filepaths(&cur_path).unwrap_or(vec![]);
+    let output = filepaths(&cur_path).unwrap_or_default();
     output
         .iter()
         .map(|x| {
@@ -275,7 +275,7 @@ fn sanitize_file_name(filename: String) -> String {
     //     static ref ESCAPE_SPACE
     // }
 
-    filename.replace(" ", "\\ ")
+    filename.replace(' ', "\\ ")
 }
 
 #[cfg(test)]

--- a/crates/shrs_line/src/completion/data.rs
+++ b/crates/shrs_line/src/completion/data.rs
@@ -1,8 +1,7 @@
 //! Collection of useful predicates and actions
 
 use super::{
-    cmdname_eq_pred, default_format, default_format_with_comment, drop_path_end, filepaths,
-    find_executables_in_path, Completer, Completion, CompletionCtx, ReplaceMethod,
+    cmdname_eq_pred, default_format, default_format_with_comment, Completion, CompletionCtx,
 };
 
 // completions for git

--- a/crates/shrs_line/src/completion/mod.rs
+++ b/crates/shrs_line/src/completion/mod.rs
@@ -4,6 +4,8 @@ mod completer;
 pub use completer::*;
 
 mod utils;
+// TODO: Report bugged warning (this reexport is required)
+#[allow(unused_imports)]
 pub use utils::*;
 
 mod data;

--- a/crates/shrs_line/src/completion/utils.rs
+++ b/crates/shrs_line/src/completion/utils.rs
@@ -33,15 +33,15 @@ pub(crate) fn filepaths(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     filepaths_p(dir, |_| true)
 }
 
-/// Generate list of all executables in PATH
-fn executables(_dir: &Path) -> std::io::Result<Vec<String>> {
-    todo!()
-}
+// /// Generate list of all executables in PATH
+// fn executables(_dir: &Path) -> std::io::Result<Vec<String>> {
+//     todo!()
+// }
 
-/// Generate list of all ssh hosts
-fn ssh_hosts(_dir: &Path) -> std::io::Result<Vec<String>> {
-    todo!()
-}
+// /// Generate list of all ssh hosts
+// fn ssh_hosts(_dir: &Path) -> std::io::Result<Vec<String>> {
+//     todo!()
+// }
 
 /// Looks through each directory in path and finds executables
 pub(crate) fn find_executables_in_path(path_str: &str) -> Vec<String> {
@@ -53,12 +53,10 @@ pub(crate) fn find_executables_in_path(path_str: &str) -> Vec<String> {
             Ok(dir) => dir,
             Err(_) => continue,
         };
-        for file in dir {
-            if let Ok(dir_entry) = file {
-                // check if file is executable
-                if dir_entry.metadata().unwrap().permissions().mode() & 0o111 != 0 {
-                    execs.push(dir_entry.file_name().to_str().unwrap().into());
-                }
+        for dir_entry in dir.flatten() {
+            // check if file is executable
+            if dir_entry.metadata().unwrap().permissions().mode() & 0o111 != 0 {
+                execs.push(dir_entry.file_name().to_str().unwrap().into());
             }
         }
     }
@@ -75,14 +73,14 @@ pub(crate) fn drop_path_end(path: &str) -> String {
     drop_end.chars().rev().collect::<String>()
 }
 
-pub(crate) fn path_end(path: &str) -> String {
-    let end = path
-        .chars()
-        .rev()
-        .take_while(|c| *c != '/')
-        .collect::<String>();
-    end.chars().rev().collect::<String>()
-}
+// pub(crate) fn path_end(path: &str) -> String {
+//     let end = path
+//         .chars()
+//         .rev()
+//         .take_while(|c| *c != '/')
+//         .collect::<String>();
+//     end.chars().rev().collect::<String>()
+// }
 
 #[cfg(test)]
 mod tests {

--- a/crates/shrs_line/src/completion/utils.rs
+++ b/crates/shrs_line/src/completion/utils.rs
@@ -33,16 +33,6 @@ pub(crate) fn filepaths(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     filepaths_p(dir, |_| true)
 }
 
-// /// Generate list of all executables in PATH
-// fn executables(_dir: &Path) -> std::io::Result<Vec<String>> {
-//     todo!()
-// }
-
-// /// Generate list of all ssh hosts
-// fn ssh_hosts(_dir: &Path) -> std::io::Result<Vec<String>> {
-//     todo!()
-// }
-
 /// Looks through each directory in path and finds executables
 pub(crate) fn find_executables_in_path(path_str: &str) -> Vec<String> {
     use std::{fs, os::unix::fs::PermissionsExt};

--- a/crates/shrs_line/src/highlight.rs
+++ b/crates/shrs_line/src/highlight.rs
@@ -1,6 +1,6 @@
 //! Syntax highlighting
 
-use std::{collections::HashMap, default, usize};
+use std::{collections::HashMap, usize};
 
 use crossterm::style::{Color, ContentStyle};
 use shrs_lang::{Lexer, Token};
@@ -104,61 +104,59 @@ pub fn shrs_rule(buf: &str) -> HashMap<usize, ContentStyle> {
 
     let mut c_style: HashMap<usize, ContentStyle> = HashMap::new();
     let mut range_insert = |start: usize, end: usize, style: ContentStyle| {
-        (start..end).into_iter().for_each(|u| {
+        (start..end).for_each(|u| {
             c_style.insert(u, style);
         })
     };
 
     let lexer = Lexer::new(buf);
     let mut is_cmd = true;
-    for t in lexer {
-        if let Ok(token) = t {
-            match token.1.clone() {
-                Token::WORD(_) => {
-                    if is_cmd {
-                        range_insert(token.0, token.2, cmd_style);
-                        is_cmd = false;
-                    }
-                },
-                //Tokens that make next word command
-                Token::IF
-                | Token::THEN
-                | Token::ELSE
-                | Token::ELIF
-                | Token::DO
-                | Token::CASE
-                | Token::AND_IF
-                | Token::OR_IF
-                | Token::SEMI
-                | Token::DSEMI
-                | Token::AMP
-                | Token::PIPE => {
-                    is_cmd = true;
-                },
-                _ => (),
-            }
-            match token.1 {
-                Token::IF
-                | Token::ELSE
-                | Token::FI
-                | Token::THEN
-                | Token::ELIF
-                | Token::DO
-                | Token::DONE
-                | Token::CASE
-                | Token::ESAC
-                | Token::WHILE
-                | Token::UNTIL
-                | Token::FOR
-                | Token::IN => {
-                    range_insert(token.0, token.2, reserved_style);
-                },
-                _ => (),
-            }
-            if let Token::WORD(w) = token.1 {
-                if w.starts_with('\'') || w.starts_with('\"') {
-                    range_insert(token.0, token.2, string_style);
+    for token in lexer.flatten() {
+        match token.1.clone() {
+            Token::WORD(_) => {
+                if is_cmd {
+                    range_insert(token.0, token.2, cmd_style);
+                    is_cmd = false;
                 }
+            },
+            //Tokens that make next word command
+            Token::IF
+            | Token::THEN
+            | Token::ELSE
+            | Token::ELIF
+            | Token::DO
+            | Token::CASE
+            | Token::AND_IF
+            | Token::OR_IF
+            | Token::SEMI
+            | Token::DSEMI
+            | Token::AMP
+            | Token::PIPE => {
+                is_cmd = true;
+            },
+            _ => (),
+        }
+        match token.1 {
+            Token::IF
+            | Token::ELSE
+            | Token::FI
+            | Token::THEN
+            | Token::ELIF
+            | Token::DO
+            | Token::DONE
+            | Token::CASE
+            | Token::ESAC
+            | Token::WHILE
+            | Token::UNTIL
+            | Token::FOR
+            | Token::IN => {
+                range_insert(token.0, token.2, reserved_style);
+            },
+            _ => (),
+        }
+        if let Token::WORD(w) = token.1 {
+            if w.starts_with('\'') || w.starts_with('\"') {
+                range_insert(token.0, token.2, string_style);
             }
         }
     }

--- a/crates/shrs_line/src/menu.rs
+++ b/crates/shrs_line/src/menu.rs
@@ -1,6 +1,6 @@
 //! General purpose selection menu for shell
 
-use std::{cmp::Ordering, fmt::Display, io::Write};
+use std::{cmp::Ordering, fmt::Display};
 
 use crossterm::{
     cursor::{MoveDown, MoveToColumn, MoveUp},
@@ -54,30 +54,34 @@ pub struct DefaultMenu {
     /// Max length in characters that the comment message is allowed to take up
     comment_max_length: usize,
     /// Max number of entries to show when rendering the menu
-    limit: usize,
+    _limit: usize,
     /// Function to use to sort the entries
     // TODO can we make this vary depending on which completions are used? does sorting belong more
     // to completion?
     sort: SortFn,
 }
 
-impl DefaultMenu {
-    pub fn new() -> Self {
+impl Default for DefaultMenu {
+    fn default() -> Self {
         DefaultMenu {
             selections: vec![],
             cursor: 0,
             active: false,
             comment_max_length: 30,
             column_padding: 2,
-            limit: 20,
+            _limit: 20,
             // by default sort alphabetical by display name
             sort: |a, b| -> Ordering { a.0.to_lowercase().cmp(&b.0.to_lowercase()) },
         }
     }
-    pub fn new_with_limit(limit: usize) -> Self {
-        let mut menu = Self::new();
-        menu.limit = limit;
-        menu
+}
+
+impl DefaultMenu {
+    pub fn new_with_limit(_limit: usize) -> Self {
+        Self {
+            _limit,
+            ..Default::default()
+        }
     }
 
     // TODO make these configurable?

--- a/crates/shrs_line/src/painter.rs
+++ b/crates/shrs_line/src/painter.rs
@@ -2,14 +2,12 @@
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
-    fmt::Display,
     io::{stdout, BufWriter, Write},
 };
 
 use crossterm::{
     cursor::{self, MoveToColumn, MoveToNextLine, MoveToPreviousLine},
-    style::{ContentStyle, Print, PrintStyledContent, StyledContent},
+    style::{Print, PrintStyledContent},
     terminal::{self, Clear, ScrollUp},
     QueueableCommand,
 };
@@ -29,16 +27,18 @@ pub struct Painter {
     num_newlines: usize,
 }
 
-impl Painter {
-    pub fn new() -> Self {
-        Painter {
+impl Default for Painter {
+    fn default() -> Self {
+        Self {
             out: RefCell::new(BufWriter::new(stdout())),
             term_size: (0, 0),
             prompt_line: 0,
             num_newlines: 0,
         }
     }
+}
 
+impl Painter {
     /// Clear screen and move prompt to the top
     pub fn init(&mut self) -> crossterm::Result<()> {
         self.prompt_line = 0;
@@ -62,6 +62,8 @@ impl Painter {
         self.term_size
     }
 
+    // Clippy thinks we can just use &dyn but we cannot
+    #[allow(clippy::borrowed_box)]
     pub fn paint<T: Prompt + ?Sized>(
         &mut self,
         line_ctx: &mut LineCtx,
@@ -74,13 +76,11 @@ impl Painter {
 
         // scroll up if we need more lines
         if menu.is_active() {
-            let required_lines = menu.required_lines(&self) as u16;
+            let required_lines = menu.required_lines(self) as u16;
             let remaining_lines = self.term_size.1.saturating_sub(self.prompt_line);
             if required_lines > remaining_lines {
                 let extra_lines = required_lines.saturating_sub(remaining_lines);
-                self.out
-                    .borrow_mut()
-                    .queue(ScrollUp(extra_lines.try_into().unwrap()))?;
+                self.out.borrow_mut().queue(ScrollUp(extra_lines))?;
                 self.prompt_line = self.prompt_line.saturating_sub(extra_lines);
             }
         }
@@ -144,7 +144,7 @@ impl Painter {
 
             if ri < prompt_right_lines.len() {
                 let mut right_space = self.term_size.0;
-                right_space -= line_content_len(prompt_right_lines[ri].clone()) as u16;
+                right_space -= line_content_len(prompt_right_lines[ri].clone());
                 self.out.borrow_mut().queue(MoveToColumn(right_space))?;
                 for span in prompt_right_lines[ri].iter() {
                     self.out
@@ -200,7 +200,7 @@ impl Painter {
 
         // render menu
         if menu.is_active() {
-            menu.render(&mut self.out.borrow_mut(), &self)?;
+            menu.render(&mut self.out.borrow_mut(), self)?;
         }
 
         //move cursor to correct position

--- a/crates/shrs_line/src/prompt.rs
+++ b/crates/shrs_line/src/prompt.rs
@@ -12,13 +12,8 @@ pub trait Prompt {
 }
 
 /// Default implementation for [Prompt]
+#[derive(Default)]
 pub struct DefaultPrompt {}
-
-impl DefaultPrompt {
-    pub fn new() -> Self {
-        DefaultPrompt {}
-    }
-}
 
 impl Prompt for DefaultPrompt {
     // TODO i still don't like passing all this context down

--- a/crates/shrs_line/src/vi.rs
+++ b/crates/shrs_line/src/vi.rs
@@ -211,7 +211,7 @@ mod test {
 
     #[test]
     fn move_next_word() -> Result<()> {
-        let mut cb = CursorBuffer::from_str("hello world goodbye world");
+        let mut cb = CursorBuffer::from_text("hello world goodbye world");
 
         assert_eq!(cb.cursor(), 0);
 
@@ -226,7 +226,7 @@ mod test {
 
     #[test]
     fn move_back_word() -> Result<()> {
-        let mut cb = CursorBuffer::from_str("hello world goodbye world");
+        let mut cb = CursorBuffer::from_text("hello world goodbye world");
         cb.execute_vi(Action::Move(Motion::End))?;
         cb.execute_vi(Action::Move(Motion::Left))?;
         assert_eq!(cb.cursor(), 24);

--- a/crates/shrs_utils/src/algo.rs
+++ b/crates/shrs_utils/src/algo.rs
@@ -3,7 +3,7 @@
 // TODO maybe this solution could use some optimization
 // Should be O(nlogn + m), where m is length of longest string in input
 pub fn longest_common_prefix(input: Vec<&str>) -> String {
-    if input.len() < 1 {
+    if input.is_empty() {
         return String::new();
     }
 

--- a/crates/shrs_utils/src/cursor_buffer.rs
+++ b/crates/shrs_utils/src/cursor_buffer.rs
@@ -119,7 +119,6 @@ impl Add for Location {
 }
 
 /// Friendly wrapper around Rope data structure
-#[derive(Default)]
 pub struct CursorBuffer {
     data: Rope,
     /// Cursor is an absolute index into the data buffer
@@ -130,6 +129,15 @@ pub struct CursorBuffer {
     ///
     /// Invariant: cursor is always valid (never need to perform bounds checking on `cursor` itself)
     cursor: usize,
+}
+
+impl Default for CursorBuffer {
+    fn default() -> Self {
+        CursorBuffer {
+            data: Rope::new(),
+            cursor: 0,
+        }
+    }
 }
 
 impl CursorBuffer {

--- a/crates/shrs_utils/src/cursor_buffer.rs
+++ b/crates/shrs_utils/src/cursor_buffer.rs
@@ -119,6 +119,7 @@ impl Add for Location {
 }
 
 /// Friendly wrapper around Rope data structure
+#[derive(Default)]
 pub struct CursorBuffer {
     data: Rope,
     /// Cursor is an absolute index into the data buffer
@@ -132,16 +133,8 @@ pub struct CursorBuffer {
 }
 
 impl CursorBuffer {
-    /// Construct an empty CursorBuffer
-    pub fn new() -> Self {
-        CursorBuffer {
-            data: Rope::new(),
-            cursor: 0,
-        }
-    }
-
-    /// Create new `CursorBuffer` from string an sets cursor location to beginning
-    pub fn from_str(text: &str) -> Self {
+    /// Create new `CursorBuffer` from string and sets cursor location to beginning
+    pub fn from_text(text: &str) -> Self {
         CursorBuffer {
             data: Rope::from_str(text),
             cursor: 0,
@@ -246,6 +239,11 @@ impl CursorBuffer {
         self.data.len_chars()
     }
 
+    /// Check whether the buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.data.len_chars() == 0
+    }
+
     /// Get char at position
     pub fn char_at(&self, loc: Location) -> Option<char> {
         self.to_absolute(loc)
@@ -290,7 +288,7 @@ impl CursorBuffer {
     }
 
     /// Get borrowed contents of CursorBuffer as a string
-    pub fn as_str<'a>(&'a self) -> Cow<'a, str> {
+    pub fn as_str(&self) -> Cow<str> {
         self.data.slice(..).into()
     }
 }
@@ -302,7 +300,7 @@ mod tests {
     #[test]
     /// Basic insert and delete test
     fn basic_insert_delete() -> Result<()> {
-        let mut cb = CursorBuffer::new();
+        let mut cb = CursorBuffer::default();
 
         cb.insert(Location::Cursor(), "hello world")?;
         assert_eq!(cb.slice(..), "hello world");
@@ -321,7 +319,7 @@ mod tests {
 
     #[test]
     fn slice() -> Result<()> {
-        let mut cb = CursorBuffer::new();
+        let mut cb = CursorBuffer::default();
 
         cb.insert(Location::Cursor(), "hello world")?;
         assert_eq!(cb.slice(..2), "he");
@@ -334,7 +332,7 @@ mod tests {
     #[test]
     /// Test overdeleting buffer
     fn over_delete() -> Result<()> {
-        let mut cb = CursorBuffer::from_str("hello");
+        let mut cb = CursorBuffer::from_text("hello");
 
         assert_eq!(
             cb.delete(Location::Cursor(), Location::Abs(200)),
@@ -346,7 +344,7 @@ mod tests {
 
     #[test]
     fn find_char() -> Result<()> {
-        let cb = CursorBuffer::from_str("hello");
+        let cb = CursorBuffer::from_text("hello");
 
         assert_eq!(
             Location::FindChar(&cb, Location::Cursor(), 'l'),
@@ -358,7 +356,7 @@ mod tests {
 
     #[test]
     fn find_char_back() -> Result<()> {
-        let mut cb = CursorBuffer::from_str("hello");
+        let mut cb = CursorBuffer::from_text("hello");
         cb.move_cursor(Location::Back(&cb))?;
 
         assert_eq!(
@@ -371,7 +369,7 @@ mod tests {
 
     #[test]
     fn utf8_basic() -> Result<()> {
-        let mut cb = CursorBuffer::from_str("こんにちは");
+        let mut cb = CursorBuffer::from_text("こんにちは");
         cb.move_cursor(Location::After())?;
 
         assert_eq!(cb.cursor(), 1);

--- a/crates/shrs_utils/src/styled_buf.rs
+++ b/crates/shrs_utils/src/styled_buf.rs
@@ -34,7 +34,7 @@ impl StyledBuf {
     pub fn lines(&self) -> Vec<Vec<StyledContent<String>>> {
         let mut lines: Vec<Vec<StyledContent<String>>> = vec![];
         let mut i = 0;
-        for line in self.content.split("\n") {
+        for line in self.content.split('\n') {
             let mut x: Vec<StyledContent<String>> = vec![];
 
             for c in line.chars() {
@@ -58,7 +58,6 @@ impl StyledBuf {
     pub fn count_newlines(&self) -> u16 {
         self.content
             .chars()
-            .into_iter()
             .filter(|c| *c == '\n')
             .count()
             .try_into()

--- a/crates/shrs_vi/src/parser.rs
+++ b/crates/shrs_vi/src/parser.rs
@@ -13,13 +13,15 @@ pub struct Parser {
     parser: CommandParser,
 }
 
-impl Parser {
-    pub fn new() -> Self {
+impl Default for Parser {
+    fn default() -> Self {
         Parser {
             parser: CommandParser::new(),
         }
     }
+}
 
+impl Parser {
     pub fn parse(&mut self, input: &str) -> Result<ast::Command, Error> {
         self.parser
             .parse(input)

--- a/docs/content/docs/shell-config/builtins.md
+++ b/docs/content/docs/shell-config/builtins.md
@@ -38,7 +38,7 @@ impl BuiltinCmd for EchoBuiltin {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> ::anyhow::Result<CmdOutput> {
         ctx.out.println(args.join(" "))?;
         Ok(CmdOutput::success())

--- a/plugins/shrs_analytics/src/builtin.rs
+++ b/plugins/shrs_analytics/src/builtin.rs
@@ -10,7 +10,7 @@ impl BuiltinCmd for AnalyticsBuiltin {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         //Args, timeframe; This session or all time
         //which metric

--- a/plugins/shrs_mux/src/builtin.rs
+++ b/plugins/shrs_mux/src/builtin.rs
@@ -28,7 +28,7 @@ impl BuiltinCmd for MuxBuiltin {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
 

--- a/plugins/shrs_mux/src/lib.rs
+++ b/plugins/shrs_mux/src/lib.rs
@@ -79,7 +79,10 @@ impl Plugin for MuxPlugin {
     fn init(&self, shell: &mut ShellConfig) -> anyhow::Result<()> {
         // This might be able to be indexed by typeid?
         let langs: Vec<(String, Box<dyn Lang>)> = vec![
-            ("shrs".into(), Box::new(PosixLang::new()) as Box<dyn Lang>),
+            (
+                "shrs".into(),
+                Box::new(PosixLang::default()) as Box<dyn Lang>,
+            ),
             ("bash".into(), Box::new(BashLang::new()) as Box<dyn Lang>),
             ("nu".into(), Box::new(NuLang::new()) as Box<dyn Lang>),
             ("py".into(), Box::new(PythonLang::new()) as Box<dyn Lang>),

--- a/plugins/shrs_output_capture/src/builtin.rs
+++ b/plugins/shrs_output_capture/src/builtin.rs
@@ -17,7 +17,7 @@ impl BuiltinCmd for AgainBuiltin {
         _sh: &Shell,
         ctx: &mut Context,
         _rt: &mut Runtime,
-        _args: &Vec<String>,
+        _args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         if let Some(state) = ctx.state.get::<OutputCaptureState>() {
             print!("{}", state.last_output.stdout);

--- a/plugins/shrs_run_context/src/builtin.rs
+++ b/plugins/shrs_run_context/src/builtin.rs
@@ -18,7 +18,7 @@ impl BuiltinCmd for SaveBuiltin {
         _sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = SaveBuiltinCli::try_parse_from(args)?;
 
@@ -61,11 +61,11 @@ impl BuiltinCmd for LoadBuiltin {
         sh: &Shell,
         ctx: &mut Context,
         rt: &mut Runtime,
-        args: &Vec<String>,
+        args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         use std::mem;
 
-        let cli = LoadBuiltinCli::parse_from(vec!["load".to_string()].iter().chain(args.iter()));
+        let cli = LoadBuiltinCli::parse_from(["load".to_string()].iter().chain(args.iter()));
 
         let mut new_rt: Option<Runtime> = None;
         if let Some(state) = ctx.state.get_mut::<RunContextState>() {

--- a/plugins/shrs_run_context/src/lib.rs
+++ b/plugins/shrs_run_context/src/lib.rs
@@ -6,7 +6,7 @@ mod builtin;
 
 use std::{
     collections::HashMap,
-    fs::{self, OpenOptions},
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -18,15 +18,12 @@ pub struct RunContextState {
     pub(crate) context_file: Option<PathBuf>,
 }
 
+#[derive(Default)]
 pub struct RunContextPlugin {
     context_file: Option<PathBuf>,
 }
 
 impl RunContextPlugin {
-    pub fn new() -> Self {
-        RunContextPlugin { context_file: None }
-    }
-
     pub fn with_file(path: &Path) -> Self {
         RunContextPlugin {
             context_file: Some(path.to_owned()),

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
 
     // =-=-= Environment variables =-=-=
     // Load environment variables from calling shell
-    let mut env = Env::new();
+    let mut env = Env::default();
     env.load();
     env.set("SHELL_NAME", "shrs_example");
 
@@ -97,7 +97,7 @@ fn main() {
     ));
 
     // =-=-= Menu =-=-=-=
-    let menu = DefaultMenu::new();
+    let menu = DefaultMenu::default();
 
     // =-=-= History =-=-=
     // Use history that writes to file on disk
@@ -184,7 +184,7 @@ a rusty POSIX shell | build {}"#,
         .with_keybinding(keybinding)
         .with_plugin(OutputCapturePlugin)
         .with_plugin(CommandTimerPlugin)
-        .with_plugin(RunContextPlugin::new())
+        .with_plugin(RunContextPlugin::default())
         .with_plugin(MuxPlugin::new())
         .with_plugin(CdStackPlugin)
         .build()


### PR DESCRIPTION
I went through and fixed all the basic Clippy style lints that came up. As a note, I recommend that we encourage the use of Clippy, and link to a guide on how to make it the default linter, in `CONTRIBUTING.md`.

Some code has been removed, some has been commented out. I figure most almost year-old dead code can be revived as needed through the repo history. Generally, though, I tried to avoid removing anything that wasn't clearly abandoned.