### PR TITLE
post init for plugins

### DIFF
--- a/crates/shrs/src/plugin.rs
+++ b/crates/shrs/src/plugin.rs
@@ -1,6 +1,7 @@
 //! Plugin System
 
 use log::warn;
+use shrs_core::shell::{Context, Runtime, Shell};
 
 use crate::ShellConfig;
 
@@ -30,11 +31,19 @@ impl Default for PluginMeta {
 
 /// Implement this trait to build your own plugins
 pub trait Plugin {
-    /// Plugin entry point
+    /// Plugin initialization
     ///
     /// Hook onto the initialization of the shell and add any hooks, functions, state variables
     /// that you would like
     fn init(&self, shell: &mut ShellConfig) -> anyhow::Result<()>;
+
+    /// Plugin post initialization
+    ///
+    /// Gets called once after the shell has completed initialization process, giving access to
+    /// shell, context, and runtime state
+    fn post_init(&self, sh: &Shell, ctx: &mut Context, rt: &mut Runtime) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     /// Return metadata related to the plugin
     fn meta(&self) -> PluginMeta {

--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -175,6 +175,8 @@ fn run_shell(
     rt: &mut Runtime,
     readline: &mut Box<dyn Readline>,
 ) -> anyhow::Result<()> {
+    // run post init for plugins
+
     // init stuff
     let res = sh.hooks.run::<StartupCtx>(
         sh,


### PR DESCRIPTION
Some plugins require context such as `Shell`, `Context`, and `Runtime` during the initialization process, so an additional `post_init` is added to Plugin trait. `post_init` will be called once for each plugin after initialization of everything else has completed.