### PR TITLE
Nithin/theme

### DIFF
--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -36,14 +36,6 @@ pub struct ShellConfig {
     #[builder(default = "Alias::default()")]
     pub alias: Alias,
 
-    /// [OutputWriter] stdout color
-    #[builder(default = "Color::White")]
-    pub out_color: Color,
-
-    /// [OutputWriter] stderr color
-    #[builder(default = "Color::Red")]
-    pub err_color: Color,
-
     /// Environment variables, see [Env]
     #[builder(default = "Env::default()")]
     pub env: Env,
@@ -148,7 +140,7 @@ impl ShellConfig {
 
         let mut ctx = Context {
             alias: self.alias,
-            out: OutputWriter::new(self.out_color, self.err_color),
+            out: OutputWriter::new(self.theme.out_color, self.theme.err_color),
 
             state: self.state,
             jobs: Jobs::default(),

--- a/crates/shrs/src/shell.rs
+++ b/crates/shrs/src/shell.rs
@@ -1,7 +1,8 @@
 //! Shell configuration options
 
-use std::{cell::RefCell, process::ExitStatus, time::Instant};
+use std::{cell::RefCell, default, process::ExitStatus, time::Instant};
 
+use ::crossterm::style::Color;
 use log::{info, warn};
 use shrs_core::prelude::*;
 use shrs_job::JobManager;
@@ -34,6 +35,14 @@ pub struct ShellConfig {
     /// Aliases, see [Alias]
     #[builder(default = "Alias::default()")]
     pub alias: Alias,
+
+    /// [OutputWriter] stdout color
+    #[builder(default = "Color::White")]
+    pub out_color: Color,
+
+    /// [OutputWriter] stderr color
+    #[builder(default = "Color::Red")]
+    pub err_color: Color,
 
     /// Environment variables, see [Env]
     #[builder(default = "Env::default()")]
@@ -139,7 +148,8 @@ impl ShellConfig {
 
         let mut ctx = Context {
             alias: self.alias,
-            out: OutputWriter::default(),
+            out: OutputWriter::new(self.out_color, self.err_color),
+
             state: self.state,
             jobs: Jobs::default(),
             startup_time: Instant::now(),

--- a/crates/shrs_core/src/output_writer.rs
+++ b/crates/shrs_core/src/output_writer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crossterm::{
-    style::{Print, PrintStyledContent},
+    style::{Color, Print, PrintStyledContent, Stylize},
     QueueableCommand,
 };
 use shrs_utils::styled_buf::StyledBuf;
@@ -15,6 +15,8 @@ pub struct OutputWriter {
     collecting: bool,
     out: String,
     err: String,
+    out_color: Color,
+    err_color: Color,
 }
 impl Default for OutputWriter {
     fn default() -> Self {
@@ -24,10 +26,19 @@ impl Default for OutputWriter {
             collecting: false,
             out: String::new(),
             err: String::new(),
+            out_color: Color::White,
+            err_color: Color::Red,
         }
     }
 }
 impl OutputWriter {
+    pub fn new(out_color: Color, err_color: Color) -> Self {
+        Self {
+            out_color,
+            err_color,
+            ..Default::default()
+        }
+    }
     pub fn begin_collecting(&mut self) {
         self.collecting = true;
     }
@@ -36,7 +47,8 @@ impl OutputWriter {
             self.err.push_str(s.to_string().as_str());
         }
 
-        self.stderr.queue(Print(s))?;
+        self.stderr
+            .queue(PrintStyledContent(s.to_string().with(self.err_color)))?;
         self.stderr.flush()?;
         Ok(())
     }
@@ -50,7 +62,8 @@ impl OutputWriter {
         if self.collecting {
             self.out.push_str(s.to_string().as_str());
         }
-        self.stdout.queue(Print(s))?;
+        self.stdout
+            .queue(PrintStyledContent(s.to_string().with(self.out_color)))?;
         self.stdout.flush()?;
         Ok(())
     }

--- a/crates/shrs_core/src/theme.rs
+++ b/crates/shrs_core/src/theme.rs
@@ -3,6 +3,9 @@
 use crossterm::style::Color;
 
 pub struct Theme {
+    pub out_color: Color,
+    pub err_color: Color,
+    pub selection_color: Color,
     pub black: Color,
     pub dark_grey: Color,
     pub red: Color,
@@ -24,6 +27,9 @@ pub struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
+            out_color: Color::White,
+            err_color: Color::Red,
+            selection_color: Color::White,
             black: Color::Black,
             dark_grey: Color::DarkGrey,
             red: Color::Red,

--- a/crates/shrs_line/src/prompt.rs
+++ b/crates/shrs_line/src/prompt.rs
@@ -1,7 +1,7 @@
 //! Shell prompt
 
 use crossterm::style::{ContentStyle, StyledContent};
-use shrs_utils::styled_buf::StyledBuf;
+use shrs_utils::{styled, styled_buf::StyledBuf};
 
 use crate::line::LineCtx;
 
@@ -18,13 +18,10 @@ pub struct DefaultPrompt {}
 impl Prompt for DefaultPrompt {
     // TODO i still don't like passing all this context down
     fn prompt_left(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
-        StyledBuf::from_iter(vec![StyledContent::new(
-            ContentStyle::new(),
-            "> ".to_string(),
-        )])
+        styled!("> ")
     }
 
     fn prompt_right(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
-        StyledBuf::from_iter(vec![])
+        styled!()
     }
 }

--- a/crates/shrs_utils/src/styled_buf.rs
+++ b/crates/shrs_utils/src/styled_buf.rs
@@ -123,16 +123,42 @@ impl<T: Display> From<StyledContent<T>> for StyledBuf {
         StyledBuf::new(value.content().to_string().as_str(), value.style().clone())
     }
 }
-impl<T: ToString> From<Option<T>> for StyledBuf {
-    fn from(value: Option<T>) -> Self {
-        let s = value.map(|x| x.to_string()).unwrap_or_default();
-        s.into()
+impl<T: Display> From<Option<StyledContent<T>>> for StyledBuf {
+    fn from(value: Option<StyledContent<T>>) -> Self {
+        if let Some(v) = value {
+            v.into()
+        } else {
+            StyledBuf::empty()
+        }
     }
 }
-impl<T: ToString, E> From<Result<T, E>> for StyledBuf {
-    fn from(value: Result<T, E>) -> Self {
-        let s = value.map(|x| x.to_string()).unwrap_or_default();
-        s.into()
+impl<T: Display, E> From<Result<StyledContent<T>, E>> for StyledBuf {
+    fn from(value: Result<StyledContent<T>, E>) -> Self {
+        if let Ok(v) = value {
+            v.into()
+        } else {
+            StyledBuf::empty()
+        }
+    }
+}
+impl From<Option<&str>> for StyledBuf {
+    fn from(value: Option<&str>) -> Self {
+        value.unwrap_or_default().into()
+    }
+}
+impl<E> From<Result<&str, E>> for StyledBuf {
+    fn from(value: Result<&str, E>) -> Self {
+        value.unwrap_or_default().into()
+    }
+}
+impl From<Option<String>> for StyledBuf {
+    fn from(value: Option<String>) -> Self {
+        value.unwrap_or_default().into()
+    }
+}
+impl<E> From<Result<String, E>> for StyledBuf {
+    fn from(value: Result<String, E>) -> Self {
+        value.unwrap_or_default().into()
     }
 }
 

--- a/plugins/shrs_command_timer/examples/command_time.rs
+++ b/plugins/shrs_command_timer/examples/command_time.rs
@@ -5,7 +5,7 @@ struct MyPrompt;
 
 impl Prompt for MyPrompt {
     fn prompt_left(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
-        StyledBuf::from_iter(vec!["> ".to_string().reset()])
+        styled!("> ")
     }
     fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf {
         let time_str = line_ctx
@@ -15,8 +15,7 @@ impl Prompt for MyPrompt {
             .and_then(|x| x.command_time())
             .map(|x| format!("{x:?}"))
             .unwrap_or(String::new());
-
-        StyledBuf::from_iter(vec![time_str.reset()])
+        styled!(time_str.reset())
     }
 }
 

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -5,6 +5,7 @@ use std::{
     process::Command,
 };
 
+use ::crossterm::style::{Attribute, Color};
 use shrs::{
     history::FileBackedHistory,
     keybindings,
@@ -33,7 +34,7 @@ impl Prompt for MyPrompt {
             return styled! {" ", indicator, " "};
         }
 
-        styled! {" ", @(blue)username(), " ", @(white,bold)top_pwd(), " ", indicator, " "}
+        styled! {" ", username().map(|u|u.with(Color::Blue)), " ", top_pwd().with(Color::White).attribute(Attribute::Bold), " ", indicator, " "}
     }
     fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf {
         let time_str = line_ctx
@@ -49,12 +50,23 @@ impl Prompt for MyPrompt {
             .get::<MuxState>()
             .map(|state| state.get_lang());
 
-        let git_branch = git::branch().map(|s| format!("git:{s}"));
+        let git_branch = git::branch().map(|s| {
+            format!("git:{s}")
+                .with(line_ctx.sh.theme.blue)
+                .attribute(Attribute::Bold)
+        });
         if !line_ctx.lines.is_empty() {
             return styled! {""};
         }
+        styled! {git_branch,
+            " ",
+            time_str,
+            " ",
+            lang,
+            " "
+        }
 
-        styled! {@(bold,blue)git_branch, " ", time_str, " ", lang, " "}
+        // styled! {@(bold,blue)git_branch, " ", time_str, " ", lang, " "}
     }
 }
 


### PR DESCRIPTION
## Changes
This pr adds out_color and err_color which automatically color OutputWriter print and print_err.
The styled macro has also been reworked. 
The goal of the styled macro is to facilitate building styledbufs from a variety of types. The previous implementation also helped with styling however the builder pattern provided by crossterm to style is already sufficient. The intermediary StyledDisplay type has also been removed.

This PR also adds #329 incidentally.

## Next Steps
Consider how options and results should be handled: currently they resolve to "" if false however when its used like here 
`styled! {git_branch, " ",time_str, " ", lang, " "}`
There will be extra space if time_str is null. Maybe consider a separator param for the macro? Otherwise users will have to break it up into conditionals.

