### PR TITLE
Make LineCtx immutable, expose cursorbuffer

### DIFF
--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -120,7 +120,7 @@ impl HistoryInd {
 
 /// Context that is passed to [Line]
 pub struct LineCtx<'a> {
-    cb: CursorBuffer,
+    pub cb: CursorBuffer,
     // TODO this is temp, find better way to store prefix of current word
     current_word: String,
     // TODO dumping history index here for now

--- a/crates/shrs_line/src/prompt.rs
+++ b/crates/shrs_line/src/prompt.rs
@@ -7,8 +7,8 @@ use crate::line::LineCtx;
 
 /// Implement this trait to create your own prompt
 pub trait Prompt {
-    fn prompt_left(&self, line_ctx: &mut LineCtx) -> StyledBuf;
-    fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf;
+    fn prompt_left(&self, line_ctx: &LineCtx) -> StyledBuf;
+    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf;
 }
 
 /// Default implementation for [Prompt]
@@ -17,14 +17,14 @@ pub struct DefaultPrompt {}
 
 impl Prompt for DefaultPrompt {
     // TODO i still don't like passing all this context down
-    fn prompt_left(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
         StyledBuf::from_iter(vec![StyledContent::new(
             ContentStyle::new(),
             "> ".to_string(),
         )])
     }
 
-    fn prompt_right(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_right(&self, _line_ctx: &LineCtx) -> StyledBuf {
         StyledBuf::from_iter(vec![])
     }
 }

--- a/plugins/shrs_cd_tools/examples/basic.rs
+++ b/plugins/shrs_cd_tools/examples/basic.rs
@@ -6,12 +6,12 @@ use shrs_cd_tools::{
 struct MyPrompt;
 
 impl Prompt for MyPrompt {
-    fn prompt_left(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
         styled! {
             " > "
         }
     }
-    fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf {
         // TODO currently very unergonomic
         let project_info = default_prompt(line_ctx);
 

--- a/plugins/shrs_cd_tools/src/lib.rs
+++ b/plugins/shrs_cd_tools/src/lib.rs
@@ -112,7 +112,7 @@ impl Plugin for DirParsePlugin {
 }
 
 /// Default example prompt that displays some information based on language
-pub fn default_prompt(line_ctx: &mut LineCtx) -> StyledBuf {
+pub fn default_prompt(line_ctx: &LineCtx) -> StyledBuf {
     if let Some(dir_parse_state) = line_ctx.ctx.state.get::<DirParseState>() {
         let rust_info: Option<String> = dir_parse_state
             .get_module_metadata::<rust::CargoToml>("rust")

--- a/plugins/shrs_command_timer/examples/command_time.rs
+++ b/plugins/shrs_command_timer/examples/command_time.rs
@@ -4,10 +4,10 @@ use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
 struct MyPrompt;
 
 impl Prompt for MyPrompt {
-    fn prompt_left(&self, _line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
         StyledBuf::from_iter(vec!["> ".to_string().reset()])
     }
-    fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf {
         let time_str = line_ctx
             .ctx
             .state

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -9,7 +9,7 @@ use shrs::{
     history::FileBackedHistory,
     keybindings,
     line::_core::shell::set_working_dir,
-    prelude::{styled_buf::StyledBuf, *},
+    prelude::{cursor_buffer::CursorBuffer, styled_buf::StyledBuf, *},
 };
 use shrs_cd_stack::{CdStackPlugin, CdStackState};
 use shrs_cd_tools::git;
@@ -24,7 +24,7 @@ use shrs_run_context::RunContextPlugin;
 struct MyPrompt;
 
 impl Prompt for MyPrompt {
-    fn prompt_left(&self, line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_left(&self, line_ctx: &LineCtx) -> StyledBuf {
         let indicator = match line_ctx.mode() {
             LineMode::Insert => String::from(">").cyan(),
             LineMode::Normal => String::from(":").yellow(),
@@ -35,7 +35,7 @@ impl Prompt for MyPrompt {
 
         styled! {" ", @(blue)username(), " ", @(white,bold)top_pwd(), " ", indicator, " "}
     }
-    fn prompt_right(&self, line_ctx: &mut LineCtx) -> StyledBuf {
+    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf {
         let time_str = line_ctx
             .ctx
             .state


### PR DESCRIPTION
LineCtx in prompt should be immutable as prompt should not change anything. Also exposing cb because it could be nice to show character index in prompt.