### PR TITLE
Add check if not on bottom of terminal

### DIFF
--- a/crates/shrs_line/src/painter.rs
+++ b/crates/shrs_line/src/painter.rs
@@ -96,7 +96,9 @@ impl Painter {
             .max(styled_buf_lines.len() - 1 + prompt_left_lines.len() - 1);
 
         //make sure num_newlines never gets smaller, and adds newlines to adjust for prompt
-        if self.num_newlines < total_newlines {
+        if self.num_newlines < total_newlines
+            && cursor::position()?.1 + self.num_newlines as u16 == self.term_size.1 - 1
+        {
             self.out
                 .borrow_mut()
                 .queue(ScrollUp((total_newlines - self.num_newlines) as u16))?;


### PR DESCRIPTION
This fixes a bug in multiline prompts where the prompt scrolls up even when it's not on the last line. This was an oversight since running cargo run always puts prompt at last line when testing.