### PR TITLE
#344: Add cd ~ to builtin

### DIFF
--- a/crates/shrs_core/src/builtin/cd.rs
+++ b/crates/shrs_core/src/builtin/cd.rs
@@ -34,13 +34,15 @@ impl BuiltinCmd for CdBuiltin {
                     ctx.out.eprintln("no OLDPWD")?;
                     return Ok(CmdOutput::error());
                 }
-            } else if path == "~" {
+            } else if let Some(remaining) = path.strip_prefix("~") {
                 match dirs::home_dir() {
-                    Some(path) => PathBuf::from(path),
+                    Some(home) => {
+                        PathBuf::from(format!("{}{}", home.to_string_lossy(), remaining))
+                    },
                     None => {
                         ctx.out.eprintln("No Home Directory")?;
                         return Ok(CmdOutput::error());
-                    },
+                    }
                 }
             } else {
                 rt.working_dir.join(Path::new(&path))

--- a/crates/shrs_core/src/builtin/cd.rs
+++ b/crates/shrs_core/src/builtin/cd.rs
@@ -25,7 +25,6 @@ impl BuiltinCmd for CdBuiltin {
         args: &[String],
     ) -> anyhow::Result<CmdOutput> {
         let cli = Cli::try_parse_from(args)?;
-
         let path = if let Some(path) = cli.path {
             // `cd -` moves us back to previous directory
             if path == "-" {
@@ -34,6 +33,14 @@ impl BuiltinCmd for CdBuiltin {
                 } else {
                     ctx.out.eprintln("no OLDPWD")?;
                     return Ok(CmdOutput::error());
+                }
+            } else if path == "~" {
+                match dirs::home_dir() {
+                    Some(path) => PathBuf::from(path),
+                    None => {
+                        ctx.out.eprintln("No Home Directory")?;
+                        return Ok(CmdOutput::error());
+                    },
                 }
             } else {
                 rt.working_dir.join(Path::new(&path))


### PR DESCRIPTION
Added to cd builtin so that `cd ~` brings user to home directory.