### PR TITLE
ssh mux lang

### DIFF
--- a/plugins/shrs_mux/Cargo.toml
+++ b/plugins/shrs_mux/Cargo.toml
@@ -17,3 +17,4 @@ shrs = { path = "../../crates/shrs", version = "^0.0.3" }
 clap = { version = "4.1", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
 ssh2 = { version = "0.9" }
+openssh = { version = "0.10.3" }

--- a/plugins/shrs_mux/Cargo.toml
+++ b/plugins/shrs_mux/Cargo.toml
@@ -16,3 +16,4 @@ repository.workspace = true
 shrs = { path = "../../crates/shrs", version = "^0.0.3" }
 clap = { version = "4.1", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
+ssh2 = { version = "0.9" }

--- a/plugins/shrs_mux/Cargo.toml
+++ b/plugins/shrs_mux/Cargo.toml
@@ -16,5 +16,4 @@ repository.workspace = true
 shrs = { path = "../../crates/shrs", version = "^0.0.3" }
 clap = { version = "4.1", features = ["derive"] }
 tokio = { version = "1.35", features = ["full"] }
-ssh2 = { version = "0.9" }
 openssh = { version = "0.10.3" }

--- a/plugins/shrs_mux/examples/basic.rs
+++ b/plugins/shrs_mux/examples/basic.rs
@@ -1,11 +1,12 @@
 use shrs::prelude::*;
-use shrs_mux::{BashLang, MuxPlugin, NuLang, PythonLang};
+use shrs_mux::{BashLang, MuxPlugin, NuLang, PythonLang, SshLang};
 
 fn main() {
     let mux_plugin = MuxPlugin::new()
         .register_lang("bash", BashLang::new())
         .register_lang("python", PythonLang::new())
-        .register_lang("nu", NuLang::new());
+        .register_lang("nu", NuLang::new())
+        .register_lang("ssh", SshLang::new());
 
     let myshell = ShellBuilder::default()
         .with_plugin(mux_plugin)

--- a/plugins/shrs_mux/examples/basic.rs
+++ b/plugins/shrs_mux/examples/basic.rs
@@ -6,7 +6,7 @@ fn main() {
         .register_lang("bash", BashLang::new())
         .register_lang("python", PythonLang::new())
         .register_lang("nu", NuLang::new())
-        .register_lang("ssh", SshLang::new());
+        .register_lang("ssh", SshLang::new("website@danieliu.xyz"));
 
     let myshell = ShellBuilder::default()
         .with_plugin(mux_plugin)

--- a/plugins/shrs_mux/src/lang/mod.rs
+++ b/plugins/shrs_mux/src/lang/mod.rs
@@ -2,8 +2,6 @@ mod bash;
 mod lang;
 mod nu;
 mod python;
+mod ssh;
 
-pub use bash::BashLang;
-pub use lang::MuxLang;
-pub use nu::NuLang;
-pub use python::PythonLang;
+pub use self::{bash::*, lang::*, nu::*, python::*, ssh::*};

--- a/plugins/shrs_mux/src/lang/ssh.rs
+++ b/plugins/shrs_mux/src/lang/ssh.rs
@@ -1,16 +1,14 @@
 use std::{
     cell::RefCell,
     env,
-    io::{BufRead, BufReader, BufWriter, Write},
     net::TcpStream,
-    process::Stdio,
     sync::{Arc, OnceLock},
 };
 
+use openssh::{Child, KnownHosts, Session, Stdio};
 use shrs::prelude::*;
-use ssh2::{Session, Stream};
 use tokio::{
-    process::{Child, ChildStdin, ChildStdout, Command},
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
     runtime,
     sync::{
         mpsc::{self, Sender},
@@ -24,50 +22,47 @@ use crate::{
 };
 
 struct SshLangCtx {
-    stdin_writer: RefCell<BufWriter<Stream>>,
+    session: Arc<Session>,
+    shell: Child<Arc<Session>>,
 }
 
 impl SshLangCtx {
     // TODO kinda ugly to be passing remote through the original SshLang too
     fn init(runtime: &runtime::Runtime, remote: &str) -> Self {
-        // TODO just use env vars for auth for now
-        let address = env::var("SHRS_SSH_ADDRESS").unwrap();
-        let username = env::var("SHRS_SSH_USERNAME").unwrap();
-        let password = env::var("SHRS_SSH_PASSWORD").unwrap();
-
-        let tcp = TcpStream::connect(address).unwrap();
-        let mut session = Session::new().unwrap();
-        session.set_tcp_stream(tcp);
-        session.handshake().unwrap();
-        session.userauth_password(&username, &password).unwrap();
-        // TODO we can implement an interactive password prompt
-        // session.userauth_keyboard_interactive();;
-
-        println!("successful auth");
-
-        let mut channel = session.channel_session().unwrap();
-        channel.request_pty("xterm", None, None).unwrap();
-        channel.shell().unwrap();
-        session.set_blocking(false);
-        // channel.exec("ls -al").unwrap();
-
         let _guard = runtime.enter();
 
-        let stdin = channel.stream(0);
-        let stdout = channel.stream(0);
-        let stderr = channel.stderr();
+        let ctx = runtime.block_on(async {
+            let session =
+                Session::connect(env::var("SHRS_SSH_ADDRESS").unwrap(), KnownHosts::Strict)
+                    .await
+                    .unwrap();
+            let session = Arc::new(session);
 
-        runtime.spawn(async {
-            let mut stdout_reader = BufReader::new(stdout).lines();
-            while let Some(Ok(line)) = stdout_reader.next() {
-                println!("{line}");
-            }
-            eprintln!("EXITED");
+            println!("connected to server");
+
+            let mut shell = session
+                .clone()
+                .arc_command("sh")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .await
+                .unwrap();
+
+            let stdout = shell.stdout().take().unwrap();
+
+            runtime.spawn(async {
+                let mut stdout_reader = BufReader::new(stdout).lines();
+                while let Some(line) = stdout_reader.next_line().await.unwrap() {
+                    println!("{line}");
+                }
+            });
+
+            SshLangCtx { session, shell }
         });
 
-        SshLangCtx {
-            stdin_writer: RefCell::new(BufWriter::new(stdin)),
-        }
+        ctx
     }
 }
 
@@ -100,14 +95,6 @@ impl Lang for SshLang {
         let lang_ctx = self
             .lang_ctx
             .get_or_init(|| SshLangCtx::init(&self.runtime, &self.remote));
-
-        // self.runtime.block_on(async {});
-        let mut stdin_writer = lang_ctx.stdin_writer.borrow_mut();
-        stdin_writer
-            .write_all((cmd.clone() + "\n").as_bytes())
-            .unwrap();
-        stdin_writer.flush().unwrap();
-        println!("wrote {cmd}");
 
         Ok(CmdOutput::success())
     }

--- a/plugins/shrs_mux/src/lang/ssh.rs
+++ b/plugins/shrs_mux/src/lang/ssh.rs
@@ -33,17 +33,14 @@ impl SshLangCtx {
         let _guard = runtime.enter();
 
         let ctx = runtime.block_on(async {
-            let session =
-                Session::connect(env::var("SHRS_SSH_ADDRESS").unwrap(), KnownHosts::Strict)
-                    .await
-                    .unwrap();
+            let session = Session::connect(remote, KnownHosts::Strict).await.unwrap();
             let session = Arc::new(session);
 
             println!("connected to server");
 
             let mut shell = session
                 .clone()
-                .arc_command("bash")
+                .arc_command("bash") // TODO let user customize the login shell
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())

--- a/plugins/shrs_mux/src/lang/ssh.rs
+++ b/plugins/shrs_mux/src/lang/ssh.rs
@@ -1,0 +1,107 @@
+use std::{process::Stdio, sync::Arc};
+
+use shrs::prelude::*;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    runtime,
+    sync::{
+        mpsc::{self, Sender},
+        RwLock,
+    },
+};
+
+use crate::{
+    interpreter::{read_err, read_out},
+    MuxState,
+};
+
+// TODO this is just a copy pasted version of PythonLang, abstract in future
+
+pub struct SshLang {
+    instance: Child,
+    /// Channel for writing to process
+    write_tx: Sender<String>,
+    runtime: runtime::Runtime,
+}
+
+impl SshLang {
+    pub fn new() -> Self {
+        let runtime = runtime::Runtime::new().unwrap();
+
+        let _guard = runtime.enter();
+
+        // TODO maybe support custom parameters to pass to command
+        let args = vec!["-tt", "website@danieliu.xyz"];
+        let mut instance = Command::new("ssh")
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to start ssh process");
+
+        let stdout = instance.stdout.take().unwrap();
+        let stderr = instance.stderr.take().unwrap();
+        let stdin = instance.stdin.take().unwrap();
+
+        runtime.spawn(async {
+            let mut stdout_reader = BufReader::new(stdout).lines();
+            while let Some(line) = stdout_reader.next_line().await.unwrap() {
+                println!("{line}");
+            }
+        });
+
+        runtime.spawn(async {
+            let mut stderr_reader = BufReader::new(stderr).lines();
+            while let Some(line) = stderr_reader.next_line().await.unwrap() {
+                eprintln!("{line}");
+            }
+        });
+
+        let (write_tx, mut write_rx) = mpsc::channel::<String>(8);
+
+        runtime.spawn(async move {
+            let mut stdin_writer = BufWriter::new(stdin);
+
+            while let Some(cmd) = write_rx.recv().await {
+                stdin_writer
+                    .write_all((cmd + "\n").as_bytes())
+                    .await
+                    .expect("ssh command failed");
+
+                stdin_writer.flush().await.unwrap();
+            }
+        });
+
+        Self {
+            instance,
+            write_tx,
+            runtime,
+        }
+    }
+}
+
+impl Lang for SshLang {
+    fn eval(
+        &self,
+        sh: &Shell,
+        ctx: &mut Context,
+        rt: &mut Runtime,
+        cmd: String,
+    ) -> shrs::anyhow::Result<CmdOutput> {
+        self.runtime.block_on(async {
+            self.write_tx.send(cmd).await.unwrap();
+        });
+
+        Ok(CmdOutput::success())
+    }
+
+    fn name(&self) -> String {
+        "ssh".to_string()
+    }
+
+    fn needs_line_check(&self, cmd: String) -> bool {
+        false
+    }
+}

--- a/plugins/shrs_mux/src/lib.rs
+++ b/plugins/shrs_mux/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::anyhow;
 use builtin::MuxBuiltin;
-pub use lang::{BashLang, MuxLang, NuLang, PythonLang};
+pub use lang::{BashLang, MuxLang, NuLang, PythonLang, SshLang};
 use lang_options::swap_lang_options;
 pub use lang_options::LangOptions;
 use shrs::prelude::*;

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -16,7 +16,7 @@ use shrs_cd_stack::{CdStackPlugin, CdStackState};
 use shrs_cd_tools::git;
 use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
 use shrs_file_logger::{FileLogger, LevelFilter};
-use shrs_mux::{BashLang, MuxPlugin, MuxState, NuLang, PythonLang};
+use shrs_mux::{BashLang, MuxPlugin, MuxState, NuLang, PythonLang, SshLang};
 use shrs_output_capture::OutputCapturePlugin;
 use shrs_run_context::RunContextPlugin;
 


### PR DESCRIPTION
resolves #369 

implementation considerations
- currently only one remote is supported for the lang
- remotes that require any interactive passkey entry doesn't work. you need to have copied your ssh key (without password) to the remote. this is mainly a limitation in the openssh crate [link](https://docs.rs/openssh/latest/openssh/struct.Session.html#method.connect)