### PR TITLE
Adding support for globbing and tilda expansion as well as quotes

### DIFF
--- a/crates/shrs_lang/Cargo.toml
+++ b/crates/shrs_lang/Cargo.toml
@@ -18,12 +18,16 @@ shrs_job = { path = "../shrs_job", version = "^0.0.3" }
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }
 regex = "1"
 nix = { version = "0.26", default-features = false, features = ["fs", "term", "process", "signal"]}
+log = { version = "0.4" }
+
 
 pino_deref = "0.1"
 
 lazy_static = "1.4"
 thiserror = "1"
 anyhow = "1"
+dirs = "5.0.1"
+glob = "0.3.1"
 
 [dev-dependencies]
 rexpect = "0.5"

--- a/crates/shrs_lang/src/grammar.lalrpop
+++ b/crates/shrs_lang/src/grammar.lalrpop
@@ -15,7 +15,6 @@ extern {
 	"|" => lexer::Token::PIPE,
 	"`" => lexer::Token::BACKTICK,
 	"=" => lexer::Token::EQUAL,
-	"\\" => lexer::Token::BACKSLASH,
 	"'" => lexer::Token::SINGLEQUOTE,
 	"\"" => lexer::Token::DOUBLEQUOTE,
 	"<" => lexer::Token::LESS,

--- a/crates/shrs_lang/src/lexer.rs
+++ b/crates/shrs_lang/src/lexer.rs
@@ -291,8 +291,7 @@ fn is_word_start(ch: char) -> bool {
 /// predicate for when to keep reading word token
 fn is_word_continue(ch: char) -> bool {
     match ch {
-        ';' | ')' | '(' | '`' | '!' | '\\' | '\'' | '"' | '>' | '<' | '&' | '|' | '{' | '}'
-        | '*' => false,
+        ';' | ')' | '(' | '`' | '!' | '\'' | '"' | '>' | '<' | '&' | '|' | '{' | '}' => false,
         _ => !ch.is_whitespace(),
     }
 }


### PR DESCRIPTION
This pr fixes #343 and #358. A function is added to expand args appropriately. The glob crate is used which covers various globbing patterns. This PR only adds support for shrs_lang and does not do anything for builtins. This function could be moved to utils and be used on builtins as well.