### PR TITLE
adding line cancel

### DIFF
--- a/crates/shrs_line/src/line.rs
+++ b/crates/shrs_line/src/line.rs
@@ -360,6 +360,18 @@ impl Line {
             Event::Paste(p) => {
                 ctx.cb.insert(Location::Cursor(), p.as_str())?;
             },
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('c'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            }) => {
+                ctx.cb.clear();
+                self.buffer_history.clear();
+                ctx.lines = String::new();
+                self.painter.newline()?;
+
+                return Ok(true);
+            },
 
             Event::Key(KeyEvent {
                 code: KeyCode::Enter,


### PR DESCRIPTION
This pr implements #379. This emulates the behaviour in most shells where pressing ctrl-c will create a newline without executing or saving the current line in history