### PR TITLE
manpages plugin

### DIFF
--- a/crates/shrs_core/src/readline/line.rs
+++ b/crates/shrs_core/src/readline/line.rs
@@ -112,7 +112,7 @@ impl LineState {
     }
 
     /// Get the contents of the prompt
-    fn get_full_command(&self) -> String {
+    pub fn get_full_command(&self) -> String {
         let mut res: String = self.lines.clone();
         let cur_line: String = self.cb.as_str().into();
         res += cur_line.as_str();

--- a/plugins/shrs_manpages/Cargo.toml
+++ b/plugins/shrs_manpages/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shrs_manpages"
+version = "0.0.4"
+description = "keybinding to open man page currently typed command"
+readme = "README.md"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+shrs = { path = "../../crates/shrs", version = "^0.0.4" }

--- a/plugins/shrs_manpages/README.md
+++ b/plugins/shrs_manpages/README.md
@@ -1,0 +1,32 @@
+
+<div align="center">
+
+# shrs_manpages
+
+keybinding to open man page currently typed command
+
+[![crates.io](https://img.shields.io/crates/v/shrs_manpages.svg)](https://crates.io/crates/shrs_manpages)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#)
+
+</div>
+
+This is a plugin for [shrs](https://github.com/MrPicklePinosaur/shrs).
+
+## Using this plugin
+
+First add this plugin to your dependencies
+```toml
+shrs_manpages = { version = "0.0.4" }
+```
+
+Then include this plugin when initializing shrs
+```rust
+use shrs::prelude::*;
+use shrs_manpages::ManPagesPlugin;
+
+let myshell = ShellBuilder::default()
+    .with_plugin(ManPagesPlugin)
+    .build()
+    .unwrap();
+
+```

--- a/plugins/shrs_manpages/README.md
+++ b/plugins/shrs_manpages/README.md
@@ -19,14 +19,21 @@ First add this plugin to your dependencies
 shrs_manpages = { version = "0.0.4" }
 ```
 
-Then include this plugin when initializing shrs
+Register your own keybinding with the manpage handler
 ```rust
 use shrs::prelude::*;
-use shrs_manpages::ManPagesPlugin;
+use shrs_manpages::{open_manpage};
+
+let keybinding = keybindings! {
+    |state|
+    "C-n" => ("Open manpage", { open_manpage(state); }),
+};
 
 let myshell = ShellBuilder::default()
-    .with_plugin(ManPagesPlugin)
+    .with_keybinding(keybinding)
     .build()
     .unwrap();
+
+myshell.run();
 
 ```

--- a/plugins/shrs_manpages/examples/basic.rs
+++ b/plugins/shrs_manpages/examples/basic.rs
@@ -1,0 +1,11 @@
+use shrs::prelude::*;
+use shrs_manpages::ManPagesPlugin;
+
+fn main() {
+    let myshell = ShellBuilder::default()
+        .with_plugin(ManPagesPlugin)
+        .build()
+        .unwrap();
+
+    myshell.run();
+}

--- a/plugins/shrs_manpages/examples/basic.rs
+++ b/plugins/shrs_manpages/examples/basic.rs
@@ -1,5 +1,5 @@
 use shrs::{prelude::*, keybindings};
-use shrs_manpages::{ManPagesPlugin, open_manpage};
+use shrs_manpages::{open_manpage};
 
 fn main() {
 
@@ -10,7 +10,6 @@ fn main() {
 
     let myshell = ShellBuilder::default()
         .with_keybinding(keybinding)
-        .with_plugin(ManPagesPlugin::new())
         .build()
         .unwrap();
 

--- a/plugins/shrs_manpages/examples/basic.rs
+++ b/plugins/shrs_manpages/examples/basic.rs
@@ -1,9 +1,16 @@
-use shrs::prelude::*;
-use shrs_manpages::ManPagesPlugin;
+use shrs::{prelude::*, keybindings};
+use shrs_manpages::{ManPagesPlugin, open_manpage};
 
 fn main() {
+
+    let keybinding = keybindings! {
+        |state|
+        "C-n" => ("Open manpage", { open_manpage(state); }),
+    };
+
     let myshell = ShellBuilder::default()
-        .with_plugin(ManPagesPlugin)
+        .with_keybinding(keybinding)
+        .with_plugin(ManPagesPlugin::new())
         .build()
         .unwrap();
 

--- a/plugins/shrs_manpages/src/lib.rs
+++ b/plugins/shrs_manpages/src/lib.rs
@@ -1,15 +1,51 @@
+use std::process::{Command, Stdio};
+
 use shrs::prelude::*;
 
-pub struct ManPagesPlugin;
+pub struct ManPagesPlugin {
+    /// The command to use to open the man page
+    man_command: Option<String>,
+}
 
 /// Grab the current line and attempt to open man page of command
-pub fn open_manpage() {
-    
+pub fn open_manpage(state: &mut LineStateBundle) {
+    // TODO IFS
+    let full_command = state.line.get_full_command();
+    let Some(command) = full_command.split(' ').next() else { return; };
+    println!("full  command '{command}'");
+
+    // TODO Spawn man command and pass `command` to it as the man page to open 
+    Command::new("man").arg(command).spawn().unwrap();
+}
+
+// TODO i don't think we actually need an entire plugin to do this
+impl ManPagesPlugin {
+
+    /// Initialize the man pages plugin to use the `man` command by default.
+    /// If you wish to specify a different man command, use [from_man_command].
+    pub fn new() -> Self {
+        ManPagesPlugin {
+            man_command: None
+        }
+    }
+
+    /// Initialize the man pages plugin using a specific command to use to open man pages
+    pub fn from_man_command<S: ToString>(man_command: S) -> Self {
+        ManPagesPlugin {
+            man_command: Some(man_command.to_string())
+        }
+    }
 }
 
 impl Plugin for ManPagesPlugin {
     fn init(&self, shell: &mut ShellConfig) -> anyhow::Result<()> {
-
+        // TODO insert keybinding in plugin init or let user do it themselves?
+        // TODO should include config for what to bind keybinding function to?
         Ok(())
+    }
+
+
+    fn meta(&self) -> PluginMeta {
+        PluginMeta::new("manpages", "keybinding to open manpage for currently typed command", None)
     }
 }

--- a/plugins/shrs_manpages/src/lib.rs
+++ b/plugins/shrs_manpages/src/lib.rs
@@ -1,0 +1,15 @@
+use shrs::prelude::*;
+
+pub struct ManPagesPlugin;
+
+/// Grab the current line and attempt to open man page of command
+pub fn open_manpage() {
+    
+}
+
+impl Plugin for ManPagesPlugin {
+    fn init(&self, shell: &mut ShellConfig) -> anyhow::Result<()> {
+
+        Ok(())
+    }
+}

--- a/plugins/shrs_manpages/src/lib.rs
+++ b/plugins/shrs_manpages/src/lib.rs
@@ -24,7 +24,7 @@ fn _open_manpage<S: AsRef<OsStr>>(state: &mut LineStateBundle, man_command: S){
     // TODO: the old cursor buffer isn't actually preserved after executing the command.
     // so we need to save the old line and restore it after
     state.line.cb.clear();
-    // state.line.cb.insert(cursor_buffer::Location::Front(), &full_command);
+    // let _ = state.line.cb.insert(cursor_buffer::Location::Front(), &full_command);
 
     // TODO after handling keybinding it seems that the line accepts the contents, so we
     // automatically run the command that was present before - open issue to allow keybindings to


### PR DESCRIPTION
resolves #398 

todo
- [ ] preserve line contents after opening man page - will handle in #432 
- [ ] when the man page is not found, the error message renders weirdly (supposedly due to newline shenanigans)