### PR TITLE
Extract LineCtx into its own struct

### DIFF
--- a/crates/shrs_core/src/readline/mod.rs
+++ b/crates/shrs_core/src/readline/mod.rs
@@ -28,7 +28,7 @@ pub use buffer_history::{BufferHistory, DefaultBufferHistory};
 pub use cursor::CursorStyle;
 pub use highlight::{DefaultHighlighter, Highlighter, SyntaxHighlighter, SyntaxTheme};
 pub use hooks::*;
-pub use line::{Line, LineBuilder, LineBuilderError, LineCtx, LineMode, Readline};
+pub use line::{Line, LineBuilder, LineBuilderError, LineStateBundle, LineMode, Readline};
 pub use menu::{DefaultMenu, Menu};
 pub use prompt::{DefaultPrompt, Prompt, *};
 pub use vi::*;

--- a/crates/shrs_core/src/readline/painter.rs
+++ b/crates/shrs_core/src/readline/painter.rs
@@ -14,7 +14,7 @@ use crossterm::{
 use shrs_utils::styled_buf::{line_content_len, StyledBuf};
 use unicode_width::UnicodeWidthStr;
 
-use super::{cursor::CursorStyle, line::LineCtx, menu::Menu, prompt::Prompt};
+use super::{cursor::CursorStyle, line::LineStateBundle, menu::Menu, prompt::Prompt};
 use crate::prelude::Completion;
 pub struct Painter {
     /// The output buffer
@@ -65,7 +65,7 @@ impl Painter {
     #[allow(clippy::borrowed_box)]
     pub fn paint<T: Prompt + ?Sized>(
         &mut self,
-        line_ctx: &mut LineCtx,
+        line_ctx: &mut LineStateBundle,
         prompt: impl AsRef<T>,
         menu: &Box<dyn Menu<MenuItem = Completion, PreviewItem = String>>,
         styled_buf: &StyledBuf,

--- a/crates/shrs_core/src/readline/prompt.rs
+++ b/crates/shrs_core/src/readline/prompt.rs
@@ -3,12 +3,12 @@
 use crossterm::style::{ContentStyle, StyledContent};
 use shrs_utils::{styled_buf, styled_buf::StyledBuf};
 
-use super::LineCtx;
+use super::LineStateBundle;
 
 /// Implement this trait to create your own prompt
 pub trait Prompt {
-    fn prompt_left(&self, line_ctx: &LineCtx) -> StyledBuf;
-    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf;
+    fn prompt_left(&self, line_ctx: &LineStateBundle) -> StyledBuf;
+    fn prompt_right(&self, line_ctx: &LineStateBundle) -> StyledBuf;
 }
 
 /// Default implementation for [Prompt]
@@ -17,11 +17,11 @@ pub struct DefaultPrompt {}
 
 impl Prompt for DefaultPrompt {
     // TODO i still don't like passing all this context down
-    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineStateBundle) -> StyledBuf {
         styled_buf!("> ")
     }
 
-    fn prompt_right(&self, _line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_right(&self, _line_ctx: &LineStateBundle) -> StyledBuf {
         styled_buf!()
     }
 }

--- a/plugins/shrs_cd_tools/examples/basic.rs
+++ b/plugins/shrs_cd_tools/examples/basic.rs
@@ -6,12 +6,12 @@ use shrs_cd_tools::{
 struct MyPrompt;
 
 impl Prompt for MyPrompt {
-    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineStateBundle) -> StyledBuf {
         styled_buf! {
             " > "
         }
     }
-    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_right(&self, line_ctx: &LineStateBundle) -> StyledBuf {
         // TODO currently very unergonomic
         let project_info = default_prompt(line_ctx);
 

--- a/plugins/shrs_cd_tools/src/lib.rs
+++ b/plugins/shrs_cd_tools/src/lib.rs
@@ -112,7 +112,7 @@ impl Plugin for DirParsePlugin {
 }
 
 /// Default example prompt that displays some information based on language
-pub fn default_prompt(line_ctx: &LineCtx) -> StyledBuf {
+pub fn default_prompt(line_ctx: &LineStateBundle) -> StyledBuf {
     if let Some(dir_parse_state) = line_ctx.ctx.state.get::<DirParseState>() {
         let rust_info: Option<String> = dir_parse_state
             .get_module_metadata::<rust::CargoToml>("rust")

--- a/plugins/shrs_command_timer/examples/command_time.rs
+++ b/plugins/shrs_command_timer/examples/command_time.rs
@@ -4,10 +4,10 @@ use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
 struct MyPrompt;
 
 impl Prompt for MyPrompt {
-    fn prompt_left(&self, _line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_left(&self, _line_ctx: &LineStateBundle) -> StyledBuf {
         styled_buf!("> ")
     }
-    fn prompt_right(&self, line_ctx: &LineCtx) -> StyledBuf {
+    fn prompt_right(&self, line_ctx: &LineStateBundle) -> StyledBuf {
         let time_str = line_ctx
             .ctx
             .state


### PR DESCRIPTION
The line ctx struct holds line state as well as `Shell`, `Runtime` and `Context`, which was a bit messy. Moved line specific state to `LineState` and created new `LineStateBundle` to hold all three states to pass around in functions.
