### PR TITLE
Adding sleep to prevent busy waiting

### DIFF
--- a/crates/shrs_core/src/lang/eval2.rs
+++ b/crates/shrs_core/src/lang/eval2.rs
@@ -8,12 +8,6 @@ use shrs_lang::ast;
 
 use crate::lang::posix_lang::PosixError;
 
-pub struct Os {
-    _job_manager: JobManager,
-    /// Exit status of last command executed.
-    _last_exit_status: ExitStatus,
-}
-
 pub fn run_job(
     job_manager: &mut JobManager,
     procs: Vec<Box<dyn Process>>,
@@ -26,10 +20,9 @@ pub fn run_job(
         foreground,
     };
 
-    let is_foreground = proc_group.foreground;
     let job_id = job_manager.create_job("", proc_group);
 
-    if is_foreground {
+    if foreground {
         job_manager
             .put_job_in_foreground(Some(job_id), false)
             .map_err(|e| PosixError::Job(e))?;

--- a/crates/shrs_job/src/job.rs
+++ b/crates/shrs_job/src/job.rs
@@ -1,4 +1,6 @@
-use std::{fmt, process::ExitStatus};
+use std::{
+    fmt, os::unix::process::ExitStatusExt, process::ExitStatus, thread::sleep, time::Duration,
+};
 
 use log::*;
 use nix::{
@@ -95,13 +97,15 @@ impl JobManager {
     /// This function also updates the statuses of other jobs if we receive
     /// a signal for one of their processes.
     pub fn wait_for_job(&mut self, job_id: JobId) -> anyhow::Result<Option<ExitStatus>> {
-        while self.job_is_running(job_id) {
+        let job_index = self.find_job(job_id).expect("job not found");
+
+        while self.job_is_running(job_index) {
             for job in &mut self.jobs {
                 job.try_wait()?;
             }
+            sleep(Duration::from_millis(100));
         }
 
-        let job_index = self.find_job(job_id).expect("job not found");
         Ok(self.jobs[job_index].last_status_code())
     }
 
@@ -222,8 +226,7 @@ impl JobManager {
 
     /// # Panics
     /// Panics if job is not found
-    fn job_is_running(&self, job_id: JobId) -> bool {
-        let job_index = self.find_job(job_id).expect("job not found");
+    fn job_is_running(&self, job_index: usize) -> bool {
         !self.jobs[job_index].is_stopped() && !self.jobs[job_index].is_completed()
     }
 


### PR DESCRIPTION
Added a small fix for #349 by preventing busy waiting when a process is running. This seems to only use a lot of cpu when running a process that outputs a lot.

Ideally the job manager should run asynchronously to update the status of the processes. Current fix is just to sleep between polls, reducing overhead to almost 0.