### PR TITLE
Update example to use FileBackedHistoryPlugin

### DIFF
--- a/shrs_example/Cargo.toml
+++ b/shrs_example/Cargo.toml
@@ -15,6 +15,7 @@ shrs_command_timer = { path = "../plugins/shrs_command_timer", version = "0.0.5"
 shrs_run_context = { path = "../plugins/shrs_run_context", version = "0.0.5" }
 shrs_mux = { path = "../plugins/shrs_mux", version = "0.0.5" }
 shrs_cd_stack = { path = "../plugins/shrs_cd_stack", version = "0.0.5" }
+shrs_file_history = { path = "../plugins/shrs_file_history", version = "0.0.5" }
 shrs_file_logger = { path = "../plugins/shrs_file_logger", version = "0.0.5" }
 shrs_rhai = { path = "../plugins/shrs_rhai", version = "0.0.5" }
 shrs_rhai_completion = { path = "../plugins/shrs_rhai_completion", version = "0.0.5" }

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -6,13 +6,13 @@ use std::{
 };
 
 use shrs::{
-    history::FileBackedHistory,
     prelude::{styled_buf::StyledBuf, *},
     readline::line::LineContents,
 };
 use shrs_cd_stack::{cd_stack_down, cd_stack_up, CdStackPlugin, CdStackState};
 use shrs_cd_tools::git;
 use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
+use shrs_file_history::FileBackedHistoryPlugin;
 use shrs_file_logger::{FileLogger, LevelFilter};
 use shrs_mux::{python::*, BashLang, MuxHighlighter, MuxPlugin, MuxState, NuLang};
 use shrs_rhai::RhaiPlugin;
@@ -107,11 +107,6 @@ fn main() {
     // =-=-= Menu =-=-=-=
     let menu = DefaultMenu::default();
 
-    // =-=-= History =-=-=
-    // Use history that writes to file on disk
-    let history_file = config_dir.as_path().join("history");
-    let history = FileBackedHistory::new(history_file).expect("Could not open history file");
-
     // =-=-= Keybindings =-=-=
     // Add basic keybindings
     let mut bindings = Keybindings::new();
@@ -192,7 +187,6 @@ a rusty POSIX shell | build {}"#,
         .with_hooks(hooks)
         .with_env(env)
         .with_alias(alias)
-        .with_history(history)
         .with_keybinding(bindings)
         .with_prompt(Prompt::from_sides(prompt_left, prompt_right))
         .with_menu(menu)
@@ -204,6 +198,7 @@ a rusty POSIX shell | build {}"#,
         .with_plugin(CdStackPlugin)
         .with_plugin(RhaiPlugin)
         .with_plugin(CompletionsPlugin)
+        .with_plugin(FileBackedHistoryPlugin::new())
         .build()
         .expect("Could not construct shell");
 


### PR DESCRIPTION
Was just checking out the project for the first time and noticed the example wasn't compiling. It appears the FileBackedHistory functionality was recently move from core into its own plugin.