### PR TITLE
Fix AutocdPlugin

### DIFF
--- a/crates/shrs/examples/custom_builtin.rs
+++ b/crates/shrs/examples/custom_builtin.rs
@@ -22,15 +22,14 @@ impl Builtin for BetterCdBuiltin {
     fn run(
         &self,
         sh: &Shell,
-        ctx: &mut Context,
-        rt: &mut Runtime,
+        rt: StateMut<Runtime>,
         args: &[String],
     ) -> ::anyhow::Result<CmdOutput> {
         // Check if supplied path starts with '@' and is a registered alias
         if let Some(arg) = args.get(0) {
             if let Some(alias) = arg.strip_prefix("@") {
                 if let Some(path) = self.aliases.get(alias) {
-                    set_working_dir(ctx, path, true).unwrap();
+                    set_working_dir(sh, &mut rt, path, true).unwrap();
                     return Ok(CmdOutput::success());
                 }
             }

--- a/crates/shrs_core/src/builtin/cd.rs
+++ b/crates/shrs_core/src/builtin/cd.rs
@@ -2,10 +2,8 @@ use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
-use super::Builtin;
 use crate::{
-    commands::{Command, Commands},
-    prelude::{CmdOutput, OutputWriter, States},
+    prelude::{CmdOutput, OutputWriter},
     shell::{set_working_dir, Runtime, Shell},
     state::StateMut,
 };

--- a/crates/shrs_core/src/cmd_output.rs
+++ b/crates/shrs_core/src/cmd_output.rs
@@ -11,7 +11,7 @@ impl CmdOutput {
         CmdOutput {
             stdout: String::new(),
             stderr: String::new(),
-            status: ExitStatus::from_raw(status),
+            status: ExitStatus::from_raw(status << 8),
         }
     }
     pub fn success() -> Self {

--- a/crates/shrs_core/src/shell.rs
+++ b/crates/shrs_core/src/shell.rs
@@ -1,15 +1,13 @@
 //! Types for internal context of shell
 
 use std::{
-    cell::RefCell,
-    collections::VecDeque,
     env,
     path::{Path, PathBuf},
     process::ExitStatus,
     time::Instant,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use dirs::home_dir;
 use log::{info, warn};
 use pino_deref::Deref;
@@ -442,7 +440,7 @@ fn run_shell(
 /// Set the current working directory
 pub fn set_working_dir(
     sh: &Shell,
-    rt: &mut Runtime,
+    rt: &mut StateMut<Runtime>,
     wd: &Path,
     run_hook: bool,
 ) -> anyhow::Result<()> {

--- a/plugins/shrs_autocd/src/lib.rs
+++ b/plugins/shrs_autocd/src/lib.rs
@@ -5,9 +5,8 @@ use shrs::prelude::*;
 pub struct AutocdPlugin;
 
 pub fn after_command_hook(
+    mut rt: StateMut<Runtime>,
     sh: &Shell,
-    sh_ctx: &mut Context,
-    sh_rt: &mut Runtime,
     ctx: &AfterCommandCtx,
 ) -> anyhow::Result<()> {
     // Bash exit code for invalid command
@@ -22,9 +21,8 @@ pub fn after_command_hook(
 
             for path in paths {
                 let path = path.unwrap();
-                println!("{:?}", path);
                 if path.file_type().unwrap().is_dir() && path.file_name() == cmd_name {
-                    set_working_dir(sh, sh_ctx, sh_rt, &path.path(), true)?;
+                    set_working_dir(sh, &mut rt, &path.path(), true)?;
                     return Ok(());
                 }
             }

--- a/plugins/shrs_run_context/src/builtin.rs
+++ b/plugins/shrs_run_context/src/builtin.rs
@@ -45,8 +45,8 @@ struct LoadBuiltinCli {
 }
 
 pub fn load_builtin(
-    mut state: StateMut<RunContextState>,
-    mut cmd: StateMut<Commands>,
+    state: StateMut<RunContextState>,
+    _cmd: StateMut<Commands>,
     mut rt: StateMut<Runtime>,
     sh: &Shell,
     args: &Vec<String>,

--- a/shrs_example/Cargo.toml
+++ b/shrs_example/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 
 [dependencies]
 shrs = { path = "../crates/shrs", version = "^0.0.5" }
+shrs_autocd = { path = "../plugins/shrs_autocd", version = "0.0.5" }
 shrs_cd_tools = { path = "../plugins/shrs_cd_tools", version = "0.0.5" }
 shrs_command_timer = { path = "../plugins/shrs_command_timer", version = "0.0.5" }
 shrs_run_context = { path = "../plugins/shrs_run_context", version = "0.0.5" }

--- a/shrs_example/src/main.rs
+++ b/shrs_example/src/main.rs
@@ -9,6 +9,7 @@ use shrs::{
     prelude::{styled_buf::StyledBuf, *},
     readline::line::LineContents,
 };
+use shrs_autocd::AutocdPlugin;
 use shrs_cd_stack::{cd_stack_down, cd_stack_up, CdStackPlugin, CdStackState};
 use shrs_cd_tools::git;
 use shrs_command_timer::{CommandTimerPlugin, CommandTimerState};
@@ -199,6 +200,7 @@ a rusty POSIX shell | build {}"#,
         .with_plugin(RhaiPlugin)
         .with_plugin(CompletionsPlugin)
         .with_plugin(FileBackedHistoryPlugin::new())
+        .with_plugin(AutocdPlugin)
         .build()
         .expect("Could not construct shell");
 


### PR DESCRIPTION
Fixes issue #439

Explanation:
TIL that rusts ExitStatus is actually analogous to a unix wait status, which encodes the exit status AND any signals that terminated the process. See libc::WEXITSTATUS [here](https://docs.rs/libc/latest/src/libc/unix/linux_like/mod.rs.html#1609-1685)